### PR TITLE
Fix Deprecation Warnings

### DIFF
--- a/src/main/java/jnr/unixsocket/Native.java
+++ b/src/main/java/jnr/unixsocket/Native.java
@@ -37,10 +37,10 @@ class Native {
                         ? new String[] { "socket", "nsl", "c" }
                         : new String[] { "c" };
     public static interface LibC {
-        static final LibC INSTANCE = Library.loadLibrary(LibC.class, libnames);
-        public static final int F_GETFL = com.kenai.constantine.platform.Fcntl.F_GETFL.value();
-        public static final int F_SETFL = com.kenai.constantine.platform.Fcntl.F_SETFL.value();
-        public static final int O_NONBLOCK = com.kenai.constantine.platform.OpenFlags.O_NONBLOCK.value();
+        
+        public static final int F_GETFL = jnr.constants.platform.Fcntl.F_GETFL.intValue();
+        public static final int F_SETFL = jnr.constants.platform.Fcntl.F_SETFL.intValue();
+        public static final int O_NONBLOCK = jnr.constants.platform.OpenFlags.O_NONBLOCK.intValue();
 
         int socket(int domain, int type, int protocol);
         int listen(int fd, int backlog);
@@ -55,13 +55,23 @@ class Native {
         int setsockopt(int s, int level, int optname, @In ByteBuffer optval, int optlen);
         String strerror(int error);
     }
+    
+    static final LibC INSTANCE;
+    
+    static {
+        LibraryLoader<LibC> loader = LibraryLoader.create(LibC.class);
+        for (String libraryName : libnames) {
+            loader.library(libraryName);
+        }
+        INSTANCE = loader.load();
+    }
 
     static final LibC libsocket() {
-        return LibC.INSTANCE;
+        return INSTANCE;
     }
 
     static final LibC libc() {
-        return LibC.INSTANCE;
+        return INSTANCE;
     }
 
     static int socket(ProtocolFamily domain, Sock type, int protocol) throws IOException {

--- a/src/main/java/jnr/unixsocket/SockAddrUnix.java
+++ b/src/main/java/jnr/unixsocket/SockAddrUnix.java
@@ -18,7 +18,7 @@
 
 package jnr.unixsocket;
 
-import com.kenai.constantine.platform.ProtocolFamily;
+import jnr.constants.platform.ProtocolFamily;
 import jnr.ffi.*;
 
 /**
@@ -30,17 +30,17 @@ abstract class SockAddrUnix extends Struct {
     protected abstract UTF8String getPathField();
     protected abstract NumberField getFamilyField();
 
-    public SockAddrUnix() {
+    SockAddrUnix() {
         super(jnr.ffi.Runtime.getSystemRuntime());
     }
 
     /**
      * Sets the protocol family of this unix socket address.
      *
-     * @param family The protocol family, usually {@link com.kenai.constantine.platform.ProtocolFamily.PF_UNIX}
+     * @param family The protocol family, usually {@link ProtocolFamily#PF_UNIX}
      */
-    public final void setFamily(ProtocolFamily family) {
-        getFamilyField().set(family.value());
+    final void setFamily(ProtocolFamily family) {
+        getFamilyField().set(family.intValue());
     }
 
 
@@ -49,7 +49,7 @@ abstract class SockAddrUnix extends Struct {
      *
      * @return The protocol family
      */
-    public final ProtocolFamily getFamily() {
+    final ProtocolFamily getFamily() {
         return ProtocolFamily.valueOf(getFamilyField().intValue());
     }
 
@@ -58,7 +58,7 @@ abstract class SockAddrUnix extends Struct {
      *
      * @param path The unix socket address
      */
-    public final void setPath(java.lang.String path) {
+    final void setPath(java.lang.String path) {
         getPathField().set(path);
     }
 
@@ -67,7 +67,7 @@ abstract class SockAddrUnix extends Struct {
      *
      * @return A String
      */
-    public final java.lang.String getPath() {
+    final java.lang.String getPath() {
         return getPathField().get();
     }
 
@@ -76,7 +76,7 @@ abstract class SockAddrUnix extends Struct {
      *
      * @return The maximum size of the address in bytes
      */
-    public int getMaximumLength() {
+    int getMaximumLength() {
         return 2 + getPathField().length();
     }
 
@@ -85,7 +85,7 @@ abstract class SockAddrUnix extends Struct {
      *
      * @return The actual size of this address, in bytes
      */
-    public int length() {
+    int length() {
         return 2 + strlen(getPathField());
     }
 
@@ -96,7 +96,7 @@ abstract class SockAddrUnix extends Struct {
      * @return An instance of <tt>SockAddrUnix</tt>
      */
     static SockAddrUnix create() {
-        return Platform.getPlatform().isBSD() ? new BSDSockAddrUnix() : new DefaultSockAddrUnix();
+        return Platform.getNativePlatform().isBSD() ? new BSDSockAddrUnix() : new DefaultSockAddrUnix();
     }
 
     private static final int strlen(UTF8String str) {

--- a/src/main/java/jnr/unixsocket/UnixSocketAddress.java
+++ b/src/main/java/jnr/unixsocket/UnixSocketAddress.java
@@ -18,7 +18,7 @@
 
 package jnr.unixsocket;
 
-import com.kenai.constantine.platform.ProtocolFamily;
+import jnr.constants.platform.ProtocolFamily;
 
 public class UnixSocketAddress extends java.net.SocketAddress {
     private final SockAddrUnix address;


### PR DESCRIPTION
The project contains various deprecation warnings which are easy to
fix:

 * replace `Library` with `LibraryLoader`
 * replace `com.kenai.constantine.platform.*` with
   `jnr.constants.platform.*`
 * make `public` methods in `SockAddrUnix` package protected since the
   class and all of its subclasses are package protected

The changes should all be backwards compatible since:

 * `SockAddrUnix` and all of its subclasses are package protected
 * `SockAddrUnix` is package protected