### PR TITLE
Add support for some getsockopt/setsockopt options.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,12 @@
       <version>0.4</version>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>com.github.jnr</groupId>
+      <artifactId>jnr-posix</artifactId>
+      <version>3.0.6</version>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/src/main/java/jnr/unixsocket/UnixSocketChannel.java
+++ b/src/main/java/jnr/unixsocket/UnixSocketChannel.java
@@ -21,6 +21,8 @@ package jnr.unixsocket;
 import jnr.constants.platform.Errno;
 import jnr.constants.platform.ProtocolFamily;
 import jnr.constants.platform.Sock;
+import jnr.constants.platform.SocketLevel;
+import jnr.constants.platform.SocketOption;
 import jnr.enxio.channels.NativeSocketChannel;
 import jnr.ffi.*;
 import jnr.ffi.byref.IntByReference;
@@ -169,5 +171,22 @@ public class UnixSocketChannel extends NativeSocketChannel {
         }
 
         return remote;
+    }
+
+    public boolean getKeepAlive() {
+        int ret = Native.getsockopt(getFD(), SocketLevel.SOL_SOCKET, SocketOption.SO_KEEPALIVE.intValue());
+        return (ret == 1) ? true : false;
+    }
+
+    public void setKeepAlive(boolean on) {
+        Native.setsockopt(getFD(), SocketLevel.SOL_SOCKET, SocketOption.SO_KEEPALIVE, on);
+    }
+
+    public int getSoTimeout() {
+        return Native.getsockopt(getFD(), SocketLevel.SOL_SOCKET, SocketOption.SO_RCVTIMEO.intValue());
+    }
+
+    public void setSoTimeout(int timeout) {
+        Native.setsockopt(getFD(), SocketLevel.SOL_SOCKET, SocketOption.SO_RCVTIMEO, timeout);
     }
 }


### PR DESCRIPTION
I would like to add support for getting/setting SO_RCVTIMEO and SO_KEEPALIVE socket option values. The motivation for this change is to get the [docker-client](https://github.com/spotify/docker-client) library to switch from using unix-socket-factory (junix-socket) to jnr-unixsocket ([spotify/docker-client Issue 98](https://github.com/spotify/docker-client/issues/98)).

Currently, getsockopt/setsockopt only support boolean/integer values but an option like SO_RCVTIMEO needs its value to be a struct timeval (sys/time.h).

This change introduces :
- Support for getting/setting a 'struct timeval' in the Native class along with
  dependence on jnr-posix
- Method in UnixSocketChannel to get/set SO_KEEPALIVE
- Method in UnixSocketChannel to get/set SO_RCVTIMEO
