### PR TITLE
Add getPath to UnixSocketAddress

### DIFF
--- a/src/main/java/jnr/unixsocket/UnixSocketAddress.java
+++ b/src/main/java/jnr/unixsocket/UnixSocketAddress.java
@@ -41,6 +41,10 @@ public class UnixSocketAddress extends java.net.SocketAddress {
     int length() {
         return address.length();
     }
+    
+    public String getPath() {
+        return address.getPath();
+    }
 
     @Override
     public String toString() {


### PR DESCRIPTION
This would be useful for JRuby `UNIXSocket.for_fd(...).path` in the future.