### PR TITLE
Fix unnamed sockets support

### DIFF
--- a/src/main/java/jnr/unixsocket/SockAddrUnix.java
+++ b/src/main/java/jnr/unixsocket/SockAddrUnix.java
@@ -26,7 +26,8 @@ import jnr.ffi.*;
  */
 abstract class SockAddrUnix extends Struct {
     public final static int ADDR_LENGTH = 108;
-    
+    public final static int HEADER_LENGTH = 2;
+
     protected abstract UTF8String getPathField();
     protected abstract NumberField getFamilyField();
 
@@ -77,7 +78,7 @@ abstract class SockAddrUnix extends Struct {
      * @return The maximum size of the address in bytes
      */
     int getMaximumLength() {
-        return 2 + getPathField().length();
+        return HEADER_LENGTH + getPathField().length();
     }
 
     /**
@@ -86,7 +87,16 @@ abstract class SockAddrUnix extends Struct {
      * @return The actual size of this address, in bytes
      */
     int length() {
-        return 2 + strlen(getPathField());
+        return HEADER_LENGTH + strlen(getPathField());
+    }
+
+    /**
+     * Gets len/family header length
+     *
+     * @return The size of header, in bytes
+     */
+    int getHeaderLength() {
+        return HEADER_LENGTH;
     }
 
     

--- a/src/main/java/jnr/unixsocket/UnixServerSocketChannel.java
+++ b/src/main/java/jnr/unixsocket/UnixServerSocketChannel.java
@@ -63,6 +63,9 @@ public class UnixServerSocketChannel extends NativeServerSocketChannel {
             return null;
         }
 
+        // Handle unnamed sockets
+        if (len.getValue() == addr.getHeaderLength()) addr.setPath("");
+
         // Always force the socket back to blocking mode
         Native.setBlocking(clientfd, true);
 

--- a/src/main/java/jnr/unixsocket/UnixSocketAddress.java
+++ b/src/main/java/jnr/unixsocket/UnixSocketAddress.java
@@ -48,7 +48,7 @@ public class UnixSocketAddress extends java.net.SocketAddress {
 
     @Override
     public String toString() {
-        return "[family=" + address.getFamily() + " path=" + address.getPath() + "]";
+        return "[family=" + address.getFamily() + " path=" + path() + "]";
     }
 
     @Override
@@ -58,6 +58,6 @@ public class UnixSocketAddress extends java.net.SocketAddress {
         UnixSocketAddress other = (UnixSocketAddress)_other;
 
         return address.getFamily() == other.address.getFamily() &&
-                address.getPath().equals(other.address.getPath());
+                path().equals(other.path());
     }
 }

--- a/src/main/java/jnr/unixsocket/UnixSocketChannel.java
+++ b/src/main/java/jnr/unixsocket/UnixSocketChannel.java
@@ -221,22 +221,30 @@ public class UnixSocketChannel extends NativeSocketChannel {
 
     static UnixSocketAddress getpeername(int sockfd) {
         UnixSocketAddress remote = new UnixSocketAddress();
-        IntByReference len = new IntByReference(remote.getStruct().getMaximumLength());
+        SockAddrUnix addr = remote.getStruct();
+        IntByReference len = new IntByReference(addr.getMaximumLength());
 
-        if (Native.libc().getpeername(sockfd, remote.getStruct(), len) < 0) {
+        if (Native.libc().getpeername(sockfd, addr, len) < 0) {
             throw new Error(Native.getLastErrorString());
         }
+
+        // Handle unnamed sockets
+        if (len.getValue() == addr.getHeaderLength()) addr.setPath("");
 
         return remote;
     }
 
     static UnixSocketAddress getsockname(int sockfd) {
         UnixSocketAddress remote = new UnixSocketAddress();
-        IntByReference len = new IntByReference(remote.getStruct().getMaximumLength());
+        SockAddrUnix addr = remote.getStruct();
+        IntByReference len = new IntByReference(addr.getMaximumLength());
 
-        if (Native.libc().getsockname(sockfd, remote.getStruct(), len) < 0) {
+        if (Native.libc().getsockname(sockfd, addr, len) < 0) {
             throw new Error(Native.getLastErrorString());
         }
+
+        // Handle unnamed sockets
+        if (len.getValue() == addr.getHeaderLength()) addr.setPath("");
 
         return remote;
     }

--- a/src/test/java/jnr/unixsocket/BasicFunctionalityTest.java
+++ b/src/test/java/jnr/unixsocket/BasicFunctionalityTest.java
@@ -105,9 +105,8 @@ public class BasicFunctionalityTest {
                     // nonblocking result
                     return false;
                 }
-                // TODO: This doesn't work for some reason.
-//                assertEquals(ADDRESS, client.getLocalSocketAddress());
-//                assertEquals("", client.getRemoteSocketAddress().getStruct().getPath());
+                assertEquals(ADDRESS, client.getLocalSocketAddress());
+                assertEquals("", client.getRemoteSocketAddress().getStruct().getPath());
 
                 client.configureBlocking(false);
                 client.register(selector, SelectionKey.OP_READ, new ClientActor(client));
@@ -130,11 +129,10 @@ public class BasicFunctionalityTest {
             try {
                 ByteBuffer buf = ByteBuffer.allocate(1024);
                 int n = channel.read(buf);
-                // TODO: This doesn't work for some reason.
-//                assertEquals(ADDRESS, channel.getRemoteSocketAddress());
+                assertEquals("", channel.getRemoteSocketAddress().getStruct().getPath());
 
                 assertEquals(DATA.length(), n);
-                
+
                 if (n > 0) {
                     buf.flip();
                     channel.write(buf);

--- a/src/test/java/jnr/unixsocket/UnixSocketChannelTest.java
+++ b/src/test/java/jnr/unixsocket/UnixSocketChannelTest.java
@@ -1,0 +1,20 @@
+package jnr.unixsocket;
+
+import org.junit.Test;
+
+import static junit.framework.Assert.*;
+
+public class UnixSocketChannelTest {
+    @Test
+    public void testForUnnamedSockets() throws Exception {
+        UnixSocketChannel[] sp = UnixSocketChannel.pair();
+
+        // getpeername check
+        assertEquals(sp[0].getRemoteSocketAddress().path(), "");
+        assertEquals(sp[1].getRemoteSocketAddress().path(), "");
+
+        // getsockname check
+        assertEquals(sp[0].getLocalSocketAddress().path(), "");
+        assertEquals(sp[1].getLocalSocketAddress().path(), "");
+    }
+}


### PR DESCRIPTION
getsockname/getpeername/accept shouldn't inspect path for unnamed
sockets. See https://linux.die.net/man/7/unix
Fixes jruby/jruby#4247