### PR TITLE
Refactor unix domain classes to extend NIO base classes (Java7)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ target/
 \.conflict\~$
 
 .idea
+/.checkstyle

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 jdk:
   - oraclejdk7
-  - openjdk6
+  - openjdk7
 notifications:
   irc:
     channels:

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-enxio</artifactId>
-      <version>0.13</version>
+      <version>0.14-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -76,8 +76,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.0.2</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.7</source>
+          <target>1.7</target>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <groupId>com.github.jnr</groupId>
   <artifactId>jnr-unixsocket</artifactId>
   <packaging>jar</packaging>
-  <version>0.13-SNAPSHOT</version>
+  <version>0.13</version>
   <name>jnr-unixsocket</name>
   <description>Native I/O access for java</description>
   <url>http://github.com/jnr/jnr-unixsocket</url>

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,11 @@
       <name>Wayne Meissner</name>
       <email>wmeissner@gmail.com</email>
     </developer>
+    <developer>
+      <id>felfert</id>
+      <name>Fritz Elfert</name>
+      <email>fritz-github@fritz-elfert.de</email>
+    </developer>
   </developers>
 
   <dependencies>
@@ -71,6 +76,46 @@
   </dependencies>
   <build>
     <plugins>
+      <!-- run findbugs check -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>findbugs-maven-plugin</artifactId>
+        <version>3.0.3</version>
+        <executions>
+          <execution>
+            <phase>process-test-classes</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <effort>Max</effort>
+          <includeTests>true</includeTests>
+          <threshold>Low</threshold>
+          <xmlOutput>true</xmlOutput>
+          <failOnError>false</failOnError>
+        </configuration>
+      </plugin>
+
+      <!-- run PMD check -->
+      <plugin>
+        <artifactId>maven-pmd-plugin</artifactId>
+        <version>3.6</version>
+        <configuration>
+          <failOnViolation>false</failOnViolation>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>process-test-classes</phase>
+            <goals>
+              <goal>check</goal>
+              <goal>cpd-check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,7 @@
         <artifactId>maven-pmd-plugin</artifactId>
         <version>3.6</version>
         <configuration>
+          <linkXRef>false</linkXRef>
           <failOnViolation>false</failOnViolation>
         </configuration>
         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <groupId>com.github.jnr</groupId>
   <artifactId>jnr-unixsocket</artifactId>
   <packaging>jar</packaging>
-  <version>0.13</version>
+  <version>0.14-SNAPSHOT</version>
   <name>jnr-unixsocket</name>
   <description>Native I/O access for java</description>
   <url>http://github.com/jnr/jnr-unixsocket</url>

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
       <id>felfert</id>
       <name>Fritz Elfert</name>
       <email>fritz-github@fritz-elfert.de</email>
+      <timezone>Europe/Berlin</timezone>
     </developer>
   </developers>
 
@@ -103,8 +104,21 @@
         <artifactId>maven-pmd-plugin</artifactId>
         <version>3.6</version>
         <configuration>
+          <verbose>true</verbose>
           <linkXRef>false</linkXRef>
           <failOnViolation>false</failOnViolation>
+          <rulesets>
+              <!-- The 5 standard rulesets -->
+              <ruleset>/rulesets/java/basic.xml</ruleset>
+              <ruleset>/rulesets/java/empty.xml</ruleset>
+              <ruleset>/rulesets/java/imports.xml</ruleset>
+              <ruleset>/rulesets/java/unnecessary.xml</ruleset>
+              <ruleset>/rulesets/java/unusedcode.xml</ruleset>
+
+              <!-- Additional rulesets, see https://pmd.github.io/pmd-5.5.1/pmd-java/rules/index.html -->
+              <ruleset>/rulesets/java/braces.xml</ruleset>
+              <ruleset>/rulesets/java/finalizers.xml</ruleset>
+          </rulesets>
         </configuration>
         <executions>
           <execution>
@@ -259,3 +273,4 @@
     </extensions>
   </build>
 </project>
+<!-- vim: set sw=2 ts=2 et -->

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,38 @@
   </dependencies>
   <build>
     <plugins>
+
+      <!-- run checkstyle check -->
+      <plugin>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>2.17</version>
+        <executions>
+          <execution>
+            <phase>process-test-classes</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <configuration>
+              <includeTestSourceDirectory>true</includeTestSourceDirectory>
+              <logViolationsToConsole>true</logViolationsToConsole>
+              <checkstyleRules>
+                <module name="Checker">
+                  <!-- Checks for Size Violations.                    -->
+                  <!-- See http://checkstyle.sf.net/config_sizes.html -->
+                  <module name="FileLength">
+                    <property name="max" value="3500" />
+                    <property name="fileExtensions" value="java"/>
+                  </module>
+                  <!-- Checks for whitespace                               -->
+                  <!-- See http://checkstyle.sf.net/config_whitespace.html -->
+                  <module name="FileTabCharacter"/>
+                </module>
+              </checkstyleRules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
       <!-- run findbugs check -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
@@ -207,7 +239,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
-	<version>2.5.5</version>
+        <version>2.5.5</version>
         <executions>
           <execution>
             <id>assemble-all</id>
@@ -273,4 +305,4 @@
     </extensions>
   </build>
 </project>
-<!-- vim: set sw=2 ts=2 et -->
+<!-- vim: set sw=2 ts=2 et: -->

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-constants</artifactId>
-      <version>0.9.3</version>
+      <version>0.9.4</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-enxio</artifactId>
-      <version>0.14-SNAPSHOT</version>
+      <version>0.13</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/src/main/java/jnr/enxio/channels/AbstractNativeDatagramChannel.java
+++ b/src/main/java/jnr/enxio/channels/AbstractNativeDatagramChannel.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2016 Fritz Elfert
+ *
+ * This file is part of the JNR project.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jnr.enxio.channels;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ByteChannel;
+import java.nio.channels.DatagramChannel;
+import java.nio.channels.spi.SelectorProvider;
+
+import jnr.constants.platform.Errno;
+
+/**
+ * A {@link java.nio.channels.Channel} implementation that uses a native unix socket
+ */
+public abstract class AbstractNativeDatagramChannel extends DatagramChannel
+        implements ByteChannel, NativeSelectableChannel {
+
+	private int fd = -1;
+
+	public AbstractNativeDatagramChannel(int fd) {
+		this(NativeSelectorProvider.getInstance(), fd);
+	}
+
+	AbstractNativeDatagramChannel(SelectorProvider provider, int fd) {
+		super(provider);
+		this.fd = fd;
+	}
+
+	public void setFD(int fd) {
+		this.fd = fd;
+	}
+
+	@Override
+	protected void implCloseSelectableChannel() throws IOException {
+		Native.close(fd);
+	}
+
+	@Override
+	protected void implConfigureBlocking(boolean block) throws IOException {
+		Native.setBlocking(fd, block);
+	}
+
+	public final int getFD() {
+		return fd;
+	}
+
+	public int read(ByteBuffer dst) throws IOException {
+
+		ByteBuffer buffer = ByteBuffer.allocate(dst.remaining());
+
+		int n = Native.read(fd, buffer);
+
+		buffer.flip();
+
+		dst.put(buffer);
+
+		switch (n) {
+		case 0:
+			return -1;
+
+		case -1:
+			Errno lastError = Native.getLastError();
+			switch (lastError) {
+			case EAGAIN:
+			case EWOULDBLOCK:
+				return 0;
+
+			default:
+				throw new IOException(Native.getLastErrorString());
+			}
+
+		default: {
+
+			return n;
+		}
+		}
+	}
+
+	@Override
+	public long read(ByteBuffer[] dsts, int offset, int length)
+			throws IOException {
+		long total = 0;
+
+		for (int i = 0; i < length; i++) {
+			ByteBuffer dst = dsts[offset + i];
+			long read = read(dst);
+			if (read == -1) {
+				return read;
+			}
+			total += read;
+		}
+
+		return total;
+	}
+
+	public int write(ByteBuffer src) throws IOException {
+
+		ByteBuffer buffer = ByteBuffer.allocate(src.remaining());
+
+		buffer.put(src);
+
+		buffer.position(0);
+
+		int n = Native.write(fd, buffer);
+
+		if (n < 0) {
+			throw new IOException(Native.getLastErrorString());
+		}
+
+		return n;
+	}
+
+	@Override
+	public long write(ByteBuffer[] srcs, int offset, int length)
+			throws IOException {
+
+		long result = 0;
+		int index = 0;
+
+		for (index = offset; index < length; index++) {
+			result += write(srcs[index]);
+		}
+
+		return result;
+	}
+
+}

--- a/src/main/java/jnr/enxio/channels/AbstractNativeSocketChannel.java
+++ b/src/main/java/jnr/enxio/channels/AbstractNativeSocketChannel.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2016 Marcus Linke
+ *
+ * This file is part of the JNR project.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jnr.enxio.channels;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ByteChannel;
+import java.nio.channels.SocketChannel;
+import java.nio.channels.spi.SelectorProvider;
+
+import jnr.constants.platform.Errno;
+import jnr.constants.platform.Shutdown;
+
+public abstract class AbstractNativeSocketChannel extends SocketChannel implements ByteChannel, NativeSelectableChannel {
+
+    private int fd = -1;
+
+    public AbstractNativeSocketChannel(int fd) {
+        this(NativeSelectorProvider.getInstance(), fd);
+    }
+
+    AbstractNativeSocketChannel(SelectorProvider provider, int fd) {
+        super(provider);
+        this.fd = fd;
+    }
+
+    public void setFD(int fd) {
+        this.fd = fd;
+    }
+
+    @Override
+    protected void implCloseSelectableChannel() throws IOException {
+        Native.close(fd);
+    }
+
+    @Override
+    protected void implConfigureBlocking(boolean block) throws IOException {
+        Native.setBlocking(fd, block);
+    }
+
+    public final int getFD() {
+        return fd;
+    }
+
+    public int read(ByteBuffer dst) throws IOException {
+
+        ByteBuffer buffer = ByteBuffer.allocate(dst.remaining());
+
+        int n = Native.read(fd, buffer);
+
+        dst.put(buffer.array());
+
+        switch (n) {
+	        case 0:
+	            return -1;
+	
+	        case -1:
+	            Errno lastError = Native.getLastError();
+	            switch (lastError) {
+	            case EAGAIN:
+	            case EWOULDBLOCK:
+	                return 0;
+	
+	            default:
+	                throw new IOException(Native.getLastErrorString());
+	            }
+	
+	        default: {
+	
+	            return n;
+	        }
+        }
+    }
+
+    public int write(ByteBuffer src) throws IOException {
+
+        ByteBuffer buffer = ByteBuffer.allocate(src.remaining());
+
+        buffer.put(src);
+
+        buffer.position(0);
+
+        int n = Native.write(fd, buffer);
+
+        if (n < 0) {
+            throw new IOException(Native.getLastErrorString());
+        }
+
+        return n;
+    }
+
+    public SocketChannel shutdownInput() throws IOException {
+        int n = Native.shutdown(fd, SHUT_RD);
+        if (n < 0) {
+            throw new IOException(Native.getLastErrorString());
+        }
+        return this;
+    }
+
+    public SocketChannel shutdownOutput() throws IOException {
+        int n = Native.shutdown(fd, SHUT_WR);
+        if (n < 0) {
+            throw new IOException(Native.getLastErrorString());
+        }
+        return this;
+    }
+
+    private static final int SHUT_RD = Shutdown.SHUT_RD.intValue();
+    private static final int SHUT_WR = Shutdown.SHUT_WR.intValue();
+}

--- a/src/main/java/jnr/enxio/channels/AbstractNativeSocketChannel.java
+++ b/src/main/java/jnr/enxio/channels/AbstractNativeSocketChannel.java
@@ -59,13 +59,15 @@ public abstract class AbstractNativeSocketChannel extends SocketChannel implemen
     }
 
     public int read(ByteBuffer dst) throws IOException {
-
+    	
         ByteBuffer buffer = ByteBuffer.allocate(dst.remaining());
 
         int n = Native.read(fd, buffer);
+        
+        buffer.flip();
 
-        dst.put(buffer.array());
-
+        dst.put(buffer);
+        
         switch (n) {
 	        case 0:
 	            return -1;

--- a/src/main/java/jnr/enxio/channels/AbstractNativeSocketChannel.java
+++ b/src/main/java/jnr/enxio/channels/AbstractNativeSocketChannel.java
@@ -139,6 +139,7 @@ public abstract class AbstractNativeSocketChannel extends SocketChannel
 		return result;
 	}
 
+	@Override
 	public SocketChannel shutdownInput() throws IOException {
 		int n = Native.shutdown(fd, SHUT_RD);
 		if (n < 0) {
@@ -147,6 +148,7 @@ public abstract class AbstractNativeSocketChannel extends SocketChannel
 		return this;
 	}
 
+	@Override
 	public SocketChannel shutdownOutput() throws IOException {
 		int n = Native.shutdown(fd, SHUT_WR);
 		if (n < 0) {

--- a/src/main/java/jnr/enxio/channels/Common.java
+++ b/src/main/java/jnr/enxio/channels/Common.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2016 Fritz Elfert
+ *
+ * This file is part of the JNR project.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jnr.enxio.channels;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import jnr.constants.platform.Errno;
+
+/**
+ * Helper class, providing common methods.
+ */
+final class Common {
+
+    private int _fd = -1;
+
+    Common(int fd) {
+        _fd = fd;
+    }
+
+    void setFD(int fd) {
+        _fd = fd;
+    }
+
+    int getFD() {
+        return _fd;
+    }
+
+    int read(ByteBuffer dst) throws IOException {
+
+        ByteBuffer buffer = ByteBuffer.allocate(dst.remaining());
+
+        int n = Native.read(_fd, buffer);
+
+        buffer.flip();
+
+        dst.put(buffer);
+
+        switch (n) {
+            case 0:
+                return -1;
+
+            case -1:
+                Errno lastError = Native.getLastError();
+                switch (lastError) {
+                    case EAGAIN:
+                    case EWOULDBLOCK:
+                        return 0;
+
+                    default:
+                        throw new IOException(Native.getLastErrorString());
+                }
+
+            default: {
+
+                         return n;
+            }
+        }
+    }
+
+    long read(ByteBuffer[] dsts, int offset, int length)
+        throws IOException {
+        long total = 0;
+
+        for (int i = 0; i < length; i++) {
+            ByteBuffer dst = dsts[offset + i];
+            long read = read(dst);
+            if (read == -1) {
+                return read;
+            }
+            total += read;
+        }
+
+        return total;
+    }
+
+    int write(ByteBuffer src) throws IOException {
+
+        ByteBuffer buffer = ByteBuffer.allocate(src.remaining());
+
+        buffer.put(src);
+
+        buffer.position(0);
+
+        int n = Native.write(_fd, buffer);
+
+        if (n < 0) {
+            throw new IOException(Native.getLastErrorString());
+        }
+
+        return n;
+    }
+
+    long write(ByteBuffer[] srcs, int offset, int length)
+        throws IOException {
+
+        long result = 0;
+        int index = 0;
+
+        for (index = offset; index < length; index++) {
+            result += write(srcs[index]);
+        }
+
+        return result;
+    }
+
+}

--- a/src/main/java/jnr/unixsocket/BindHandler.java
+++ b/src/main/java/jnr/unixsocket/BindHandler.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2016 Fritz Elfert
+ *
+ * This file is part of the JNR project.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jnr.unixsocket;
+
+import java.io.IOException;
+import java.net.SocketAddress;
+
+import java.nio.channels.UnsupportedAddressTypeException;
+import java.nio.channels.AlreadyBoundException;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Helper class, providing common handling of bind() handling.
+ */
+final class BindHandler {
+    private final AtomicBoolean bound;
+
+    BindHandler(boolean initialState) {
+        bound = new AtomicBoolean(initialState);
+    }
+
+    boolean isBound() {
+        return bound.get();
+    }
+
+    synchronized UnixSocketAddress bind(int fd, SocketAddress local) throws IOException {
+        if (null != local && !(local instanceof UnixSocketAddress)) {
+            throw new UnsupportedAddressTypeException();
+        }
+        if (bound.get()) {
+            throw new AlreadyBoundException();
+        } else {
+            UnixSocketAddress ret = Common.bind(fd, (UnixSocketAddress)local);
+            bound.set(true);
+            return ret;
+        }
+    }
+
+}

--- a/src/main/java/jnr/unixsocket/Common.java
+++ b/src/main/java/jnr/unixsocket/Common.java
@@ -112,9 +112,15 @@ final class Common {
         if (null == value) {
             throw new IllegalArgumentException("Invalid option value");
         }
+
+        jnr.constants.platform.SocketOption optname = wMap.get(name);
+        if (null == optname) {
+            throw new AssertionError("Option not found or not writable");
+        }
+
         Class<?> type = name.type();
         if (type != Integer.class && type != Boolean.class) {
-            throw new AssertionError("Should not reach here");
+            throw new AssertionError("Unsupported option type");
         }
 
         int optvalue;
@@ -131,9 +137,11 @@ final class Common {
             }
         }
 
-        jnr.constants.platform.SocketOption optname = wMap.get(name);
-        if (null == optname) {
-            throw new AssertionError("Option not found");
+        if (name == UnixSocketOptions.SO_RCVTIMEO || name == UnixSocketOptions.SO_SNDTIMEO) {
+            int i = ((Integer)value).intValue();
+            if (i < 0) {
+                throw new IllegalArgumentException("Invalid send/receive timeout");
+            }
         }
 
         if (0 != Native.setsockopt(fd, SocketLevel.SOL_SOCKET, optname, optvalue)) {

--- a/src/main/java/jnr/unixsocket/Common.java
+++ b/src/main/java/jnr/unixsocket/Common.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2016 Fritz Elfert
+ * 
+ * This file is part of the JNR project.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
+package jnr.unixsocket;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import jnr.constants.platform.ProtocolFamily;
+
+import jnr.ffi.Platform;
+import jnr.ffi.Platform.OS;
+import jnr.ffi.byref.IntByReference;
+
+/**
+ * Helper class, providing common methods.
+ */
+final class Common {
+
+    private static OS currentOS = Platform.getNativePlatform().getOS();
+
+    private Common() {
+    }
+
+    static UnixSocketAddress bind(int fd, UnixSocketAddress local) throws IOException {
+        SockAddrUnix sa;
+        if (null == local) {
+            // Support autobind
+            sa = SockAddrUnix.create();
+            sa.setFamily(ProtocolFamily.PF_UNIX);
+            if (currentOS == OS.LINUX) {
+                // On Linux, we simply set an empty path
+                sa.setPath("");
+            } else {
+                // Emulate something similar (bind to some random unique address),
+                // but use regular namespace
+                File f = Files.createTempFile("jnr-unixsocket-tmp", ".sock").toFile();
+                f.deleteOnExit();
+                f.delete();
+                sa.setPath(f.getPath());
+            }
+        } else {
+            sa = local.getStruct();
+        }
+        if (Native.bind(fd, sa, sa.length()) < 0) {
+            throw new IOException(Native.getLastErrorString());
+        }
+        return getsockname(fd);
+    }
+
+    static UnixSocketAddress getsockname(int sockfd) {
+        UnixSocketAddress local = new UnixSocketAddress();
+        SockAddrUnix addr = local.getStruct();
+        int maxLength = addr.getMaximumLength();
+		IntByReference len = new IntByReference(addr.getMaximumLength());
+
+		if (Native.libc().getsockname(sockfd, addr, len) < 0) {
+			throw new Error(Native.getLastErrorString());
+		}
+        addr.updatePath(len.getValue());
+        return local;
+    }
+
+	static UnixSocketAddress getpeername(int sockfd) {
+		UnixSocketAddress remote = new UnixSocketAddress();
+        SockAddrUnix addr = remote.getStruct();
+        int maxLength = addr.getMaximumLength();
+		IntByReference len = new IntByReference(maxLength);
+
+		if (Native.libc().getpeername(sockfd, addr, len) < 0) {
+			throw new Error(Native.getLastErrorString());
+		}
+        addr.updatePath(len.getValue());
+		return remote;
+	}
+
+}

--- a/src/main/java/jnr/unixsocket/Common.java
+++ b/src/main/java/jnr/unixsocket/Common.java
@@ -67,27 +67,25 @@ final class Common {
     static UnixSocketAddress getsockname(int sockfd) {
         UnixSocketAddress local = new UnixSocketAddress();
         SockAddrUnix addr = local.getStruct();
-        int maxLength = addr.getMaximumLength();
-		IntByReference len = new IntByReference(addr.getMaximumLength());
+        IntByReference len = new IntByReference(addr.getMaximumLength());
 
-		if (Native.libc().getsockname(sockfd, addr, len) < 0) {
-			throw new Error(Native.getLastErrorString());
-		}
+        if (Native.libc().getsockname(sockfd, addr, len) < 0) {
+            throw new Error(Native.getLastErrorString());
+        }
         addr.updatePath(len.getValue());
         return local;
     }
 
-	static UnixSocketAddress getpeername(int sockfd) {
-		UnixSocketAddress remote = new UnixSocketAddress();
+    static UnixSocketAddress getpeername(int sockfd) {
+        UnixSocketAddress remote = new UnixSocketAddress();
         SockAddrUnix addr = remote.getStruct();
-        int maxLength = addr.getMaximumLength();
-		IntByReference len = new IntByReference(maxLength);
+        IntByReference len = new IntByReference(addr.getMaximumLength());
 
-		if (Native.libc().getpeername(sockfd, addr, len) < 0) {
-			throw new Error(Native.getLastErrorString());
-		}
+        if (Native.libc().getpeername(sockfd, addr, len) < 0) {
+            throw new Error(Native.getLastErrorString());
+        }
         addr.updatePath(len.getValue());
-		return remote;
-	}
+        return remote;
+    }
 
 }

--- a/src/main/java/jnr/unixsocket/Common.java
+++ b/src/main/java/jnr/unixsocket/Common.java
@@ -20,9 +20,13 @@ package jnr.unixsocket;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.SocketOption;
 import java.nio.file.Files;
+import java.util.Map;
+import java.util.HashMap;
 
 import jnr.constants.platform.ProtocolFamily;
+import jnr.constants.platform.SocketLevel;
 
 import jnr.ffi.Platform;
 import jnr.ffi.Platform.OS;
@@ -88,4 +92,64 @@ final class Common {
         return remote;
     }
 
+    static <T> T getSocketOption(int fd, SocketOption<?> name) throws IOException {
+        jnr.constants.platform.SocketOption optname = rMap.get(name);
+        if (null == optname) {
+            throw new AssertionError("Option not found");
+        }
+        Class<?> type = name.type();
+        if (type == Credentials.class) {
+            return (T) Credentials.getCredentials(fd);
+        }
+        if (type == Integer.class) {
+            return (T) Integer.valueOf(Native.getsockopt(fd, SocketLevel.SOL_SOCKET, optname.intValue()));
+        }
+        return (T) Boolean.valueOf(Native.getboolsockopt(fd, SocketLevel.SOL_SOCKET, optname.intValue()));
+    }
+
+    static void setSocketOption(int fd, SocketOption<?> name,
+            Object value) throws IOException {
+        if (null == value) {
+            throw new IllegalArgumentException("Invalid option value");
+        }
+        Class<?> type = name.type();
+        if (type != Integer.class && type != Boolean.class) {
+            throw new AssertionError("Should not reach here");
+        }
+
+        int optvalue;
+        if (type == Integer.class) {
+            optvalue = ((Integer)value).intValue();
+        } else {
+            optvalue = ((Boolean)value).booleanValue() ? 1 : 0;
+        }
+
+        if (name == UnixSocketOptions.SO_RCVBUF || name == UnixSocketOptions.SO_SNDBUF) {
+            int i = ((Integer)value).intValue();
+            if (i < 0) {
+                throw new IllegalArgumentException("Invalid send/receive buffer size");
+            }
+        }
+
+        jnr.constants.platform.SocketOption optname = wMap.get(name);
+        if (null == optname) {
+            throw new AssertionError("Option not found");
+        }
+
+        if (0 != Native.setsockopt(fd, SocketLevel.SOL_SOCKET, optname, optvalue)) {
+            throw new IOException(Native.getLastErrorString());
+        }
+    }
+
+    private static final Map<SocketOption<?>,jnr.constants.platform.SocketOption> wMap = new HashMap<>();
+    private static final Map<SocketOption<?>,jnr.constants.platform.SocketOption> rMap = new HashMap<>();
+    static {
+        wMap.put(UnixSocketOptions.SO_RCVBUF, jnr.constants.platform.SocketOption.SO_RCVBUF);
+        wMap.put(UnixSocketOptions.SO_SNDBUF, jnr.constants.platform.SocketOption.SO_SNDBUF);
+        wMap.put(UnixSocketOptions.SO_RCVTIMEO, jnr.constants.platform.SocketOption.SO_RCVTIMEO);
+        wMap.put(UnixSocketOptions.SO_SNDTIMEO, jnr.constants.platform.SocketOption.SO_SNDTIMEO);
+        wMap.put(UnixSocketOptions.SO_KEEPALIVE, jnr.constants.platform.SocketOption.SO_KEEPALIVE);
+        rMap.putAll(wMap);
+        rMap.put(UnixSocketOptions.SO_PEERCRED, jnr.constants.platform.SocketOption.SO_PEERCRED);
+    }
 }

--- a/src/main/java/jnr/unixsocket/Credentials.java
+++ b/src/main/java/jnr/unixsocket/Credentials.java
@@ -43,7 +43,7 @@ public final class Credentials {
         return java.lang.String.format("[uid=%d gid=%d pid=%d]", getUid(), getGid(), getPid());
     }
 
-    static final Credentials getCredentials(int fd) {
+    static Credentials getCredentials(int fd) {
         Ucred c = new Ucred();
         int error = Native.getsockopt(fd, SocketLevel.SOL_SOCKET, SocketOption.SO_PEERCRED, c);
         if (error != 0) {

--- a/src/main/java/jnr/unixsocket/Credentials.java
+++ b/src/main/java/jnr/unixsocket/Credentials.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright (C) 2014 Greg Vanore
+ *
  * This file is part of the JNR project.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,6 +21,16 @@ package jnr.unixsocket;
 import jnr.constants.platform.SocketLevel;
 import jnr.constants.platform.SocketOption;
 
+/**
+ * This class represents the peer credentials, retrievable from an AF_UNIX socket.
+ * <p>
+ * An instance of this class can be retrieved, using either the socket-level methods
+ * {@link UnixSocket#getCredentials} and {@link UnixDatagramSocket#getCredentials} or by specifying
+ * {@link UnixSocketOptions#SO_PEERCRED} as argument to one of the
+ * channel-level methods {@link UnixSocketChannel#getOption} and {@link UnixDatagramChannel#getOption}.
+ * <p>
+ * <b>See also:</b> <a href="http://man7.org/linux/man-pages/man7/socket.7.html">socket (7)</a>
+ */
 public final class Credentials {
     private final Ucred ucred;
 
@@ -26,18 +38,33 @@ public final class Credentials {
         this.ucred = ucred;
     }
 
+    /**
+     * Retrieves the peer's process ID.
+     * @return The PID.
+     */
     public int getPid() {
         return ucred.getPidField().intValue();
     }
 
+    /**
+     * Retrieves the peer's numeric effective user ID.
+     * @return The EUID.
+     */
     public int getUid() {
         return ucred.getUidField().intValue();
     }
 
+    /**
+     * Retrieves the peer's numeric effective group ID.
+     * @return The EGID.
+     */
     public int getGid() {
         return ucred.getGidField().intValue();
     }
 
+    /**
+     * Returns a human readable description of this instance.
+     */
     @Override
     public java.lang.String toString() {
         return java.lang.String.format("[uid=%d gid=%d pid=%d]", getUid(), getGid(), getPid());

--- a/src/main/java/jnr/unixsocket/Native.java
+++ b/src/main/java/jnr/unixsocket/Native.java
@@ -28,7 +28,6 @@ import jnr.constants.platform.Sock;
 import jnr.constants.platform.SocketLevel;
 import jnr.constants.platform.SocketOption;
 import jnr.ffi.LastError;
-import jnr.ffi.Library;
 import jnr.ffi.LibraryLoader;
 import jnr.ffi.Platform;
 import jnr.ffi.Pointer;
@@ -47,11 +46,11 @@ class Native {
     static final String[] libnames = Platform.getNativePlatform().getOS() == Platform.OS.SOLARIS
                         ? new String[] { "socket", "nsl", Platform.getNativePlatform().getStandardCLibraryName() }
                         : new String[] { Platform.getNativePlatform().getStandardCLibraryName() };
-    public static interface LibC {
+    public interface LibC {
         
-        public static final int F_GETFL = jnr.constants.platform.Fcntl.F_GETFL.intValue();
-        public static final int F_SETFL = jnr.constants.platform.Fcntl.F_SETFL.intValue();
-        public static final int O_NONBLOCK = jnr.constants.platform.OpenFlags.O_NONBLOCK.intValue();
+        int F_GETFL = jnr.constants.platform.Fcntl.F_GETFL.intValue();
+        int F_SETFL = jnr.constants.platform.Fcntl.F_SETFL.intValue();
+        int O_NONBLOCK = jnr.constants.platform.OpenFlags.O_NONBLOCK.intValue();
 
         int socket(int domain, int type, int protocol);
         int listen(int fd, int backlog);
@@ -121,11 +120,11 @@ class Native {
     }
 
     static String getLastErrorString() {
-        return strerror(LastError.getLastError(jnr.ffi.Runtime.getSystemRuntime()));
+        return strerror(LastError.getLastError(Runtime.getSystemRuntime()));
     }
 
     static Errno getLastError() {
-        return Errno.valueOf(LastError.getLastError(jnr.ffi.Runtime.getSystemRuntime()));
+        return Errno.valueOf(LastError.getLastError(Runtime.getSystemRuntime()));
     }
 
     static String strerror(int error) {
@@ -165,7 +164,7 @@ class Native {
             DefaultNativeTimeval t = new DefaultNativeTimeval(Runtime.getSystemRuntime());
             ref = new IntByReference(DefaultNativeTimeval.size(t));
             Native.libsocket().getsockopt(s, level.intValue(), optname, t, ref);
-            return (t.tv_sec.intValue() * 1000) + (t.tv_usec.intValue() / 1000);
+            return (t.tv_sec.intValue() * 1000 + t.tv_usec.intValue() / 1000);
         } else {
             ByteBuffer buf = ByteBuffer.allocate(4);
             buf.order(ByteOrder.BIG_ENDIAN);
@@ -189,7 +188,7 @@ class Native {
 
     public static int sendto(int fd, ByteBuffer src, SockAddrUnix addr, int len) throws IOException {
         if (src == null) {
-            throw new NullPointerException("Source buffer cannot be null");
+            throw new IllegalArgumentException("Source buffer cannot be null");
         }
 
         int n;
@@ -206,7 +205,7 @@ class Native {
 
     public static int recvfrom(int fd, ByteBuffer dst, SockAddrUnix addr) throws IOException {
         if (dst == null) {
-            throw new NullPointerException("Destination buffer cannot be null");
+            throw new IllegalArgumentException("Destination buffer cannot be null");
         }
         if (dst.isReadOnly()) {
             throw new IllegalArgumentException("Read-only buffer");

--- a/src/main/java/jnr/unixsocket/Native.java
+++ b/src/main/java/jnr/unixsocket/Native.java
@@ -148,7 +148,7 @@ class Native {
     public static int setsockopt(int s, SocketLevel level, SocketOption optname, int optval) {
         if (optname == SocketOption.SO_RCVTIMEO || optname == SocketOption.SO_SNDTIMEO) {
             DefaultNativeTimeval t = new DefaultNativeTimeval(Runtime.getSystemRuntime());
-            t.setTime(new long [] {optval / 1000, (optval % 1000) * 1000});
+            t.setTime(new long [] {optval / 1000, ((long)optval % 1000) * 1000});
             return libsocket().setsockopt(s, level.intValue(), optname.intValue(), t, DefaultNativeTimeval.size(t));
         } else {
             ByteBuffer buf = ByteBuffer.allocate(4);

--- a/src/main/java/jnr/unixsocket/Native.java
+++ b/src/main/java/jnr/unixsocket/Native.java
@@ -146,7 +146,7 @@ class Native {
     }
 
     public static int setsockopt(int s, SocketLevel level, SocketOption optname, int optval) {
-        if (optname == SocketOption.SO_RCVTIMEO) {
+        if (optname == SocketOption.SO_RCVTIMEO || optname == SocketOption.SO_SNDTIMEO) {
             DefaultNativeTimeval t = new DefaultNativeTimeval(Runtime.getSystemRuntime());
             t.setTime(new long [] {optval / 1000, (optval % 1000) * 1000});
             return libsocket().setsockopt(s, level.intValue(), optname.intValue(), t, DefaultNativeTimeval.size(t));
@@ -160,7 +160,7 @@ class Native {
 
     public static int getsockopt (int s, SocketLevel level, int optname) {
         IntByReference ref;
-        if (optname == SocketOption.SO_RCVTIMEO.intValue()) {
+        if (optname == SocketOption.SO_RCVTIMEO.intValue() || optname == SocketOption.SO_SNDTIMEO.intValue()) {
             DefaultNativeTimeval t = new DefaultNativeTimeval(Runtime.getSystemRuntime());
             ref = new IntByReference(DefaultNativeTimeval.size(t));
             Native.libsocket().getsockopt(s, level.intValue(), optname, t, ref);

--- a/src/main/java/jnr/unixsocket/SockAddrUnix.java
+++ b/src/main/java/jnr/unixsocket/SockAddrUnix.java
@@ -90,8 +90,10 @@ abstract class SockAddrUnix extends Struct {
         } else {
             // All others might return a len > 0 (typically 14) AND the path is terminated
             // by a NUL byte if it is shorter than sizeof(sun_path)
-            if (len < HEADER_LENGTH + getPathField().length()) {
-                cachedPath = getPathField().get().substring(0, len - HEADER_LENGTH);
+            cachedPath = getPathField().get();
+            int slen = len - HEADER_LENGTH;
+            if (slen < getPathField().length() && slen >= 0 && slen < cachedPath.length()) {
+                cachedPath = cachedPath.substring(0, slen);
             }
         }
     }

--- a/src/main/java/jnr/unixsocket/SockAddrUnix.java
+++ b/src/main/java/jnr/unixsocket/SockAddrUnix.java
@@ -94,8 +94,12 @@ abstract class SockAddrUnix extends Struct {
             // by a NUL byte if it is shorter than sizeof(sun_path)
             cachedPath = getPathField().get();
             int slen = len - HEADER_LENGTH;
-            if (slen < getPathField().length() && slen >= 0 && slen < cachedPath.length()) {
-                cachedPath = cachedPath.substring(0, slen);
+            if (slen <= 0) {
+                cachedPath = "";
+            } else {
+                if (slen < getPathField().length() && slen < cachedPath.length()) {
+                    cachedPath = cachedPath.substring(0, slen);
+                }
             }
         }
     }

--- a/src/main/java/jnr/unixsocket/SockAddrUnix.java
+++ b/src/main/java/jnr/unixsocket/SockAddrUnix.java
@@ -19,20 +19,29 @@
 package jnr.unixsocket;
 
 import jnr.constants.platform.ProtocolFamily;
-import jnr.ffi.*;
+import jnr.ffi.Platform;
+import jnr.ffi.Platform.OS;
+import jnr.ffi.Runtime;
+import jnr.ffi.Struct;
 
 /**
  * Native unix domain socket address structure.
  */
 abstract class SockAddrUnix extends Struct {
+
+    private static transient OS currentOS = Platform.getNativePlatform().getOS();
     public final static int ADDR_LENGTH = 108;
     public final static int HEADER_LENGTH = 2;
 
     protected abstract UTF8String getPathField();
     protected abstract NumberField getFamilyField();
 
+    // This is important to be cached here for supporting abstract namespace on Linux
+    // (which starts with a NUL byte. path is NOT NUL terminated in this case!)
+    private java.lang.String cachedPath;
+
     SockAddrUnix() {
-        super(jnr.ffi.Runtime.getSystemRuntime());
+        super(Runtime.getSystemRuntime());
     }
 
     /**
@@ -60,7 +69,31 @@ abstract class SockAddrUnix extends Struct {
      * @param path The unix socket address
      */
     void setPath(java.lang.String path) {
-        getPathField().set(path);
+        cachedPath = path;
+        getPathField().set(cachedPath);
+    }
+
+    /**
+     * Updates the file system path of this socket address.
+     * In order to support abstract namespaces, this MUST be
+     * called after any native syscall that sets this
+     * path struct like getsockname(), getpeername(), accept().
+     *
+     * @param len the value of the addrlen var, set by the above syscalls.
+     */
+    void updatePath(final int len) {
+        if (currentOS == OS.LINUX) {
+            // Linux always returns an accurate length in
+            // order to support abstract namespace, where
+            // path STARTS with a NUL byte.
+            cachedPath = len == HEADER_LENGTH ? "" : getPath(len - HEADER_LENGTH);
+        } else {
+            // All others might return a len > 0 (typically 14) AND the path is terminated
+            // by a NUL byte if it is shorter than sizeof(sun_path)
+            if (len < HEADER_LENGTH + getPathField().length()) {
+                cachedPath = getPathField().get().substring(0, len - HEADER_LENGTH);
+            }
+        }
     }
 
     /**
@@ -69,7 +102,28 @@ abstract class SockAddrUnix extends Struct {
      * @return A String
      */
     final java.lang.String getPath() {
-        return getPathField().get();
+        if (null == cachedPath) {
+            cachedPath = getPathField().get();
+        }
+        return cachedPath;
+    }
+
+    /**
+     * Gets the path of this socket address, supporting abstract namespace on Linux.
+     *
+     * @param len The desired length of the string.
+     * If the first character of the path is NUL, then this value ist considered
+     * exact, otherwise it includes a trailing NUL charater and therefore the actual
+     * string length is len - 1.
+     */
+    final java.lang.String getPath(int len) {
+        UTF8String str = getPathField();
+        byte [] ba = new byte[str.length()];
+        str.getMemory().get(str.offset(), ba, 0, len);
+        if (0 != ba[0]) {
+            len -= 1;
+        }
+        return new java.lang.String(java.util.Arrays.copyOf(ba, len));
     }
 
     /**
@@ -87,6 +141,9 @@ abstract class SockAddrUnix extends Struct {
      * @return The actual size of this address, in bytes
      */
     int length() {
+        if (currentOS == OS.LINUX && null != cachedPath) {
+            return HEADER_LENGTH + cachedPath.length();
+        }
         return HEADER_LENGTH + strlen(getPathField());
     }
 
@@ -128,10 +185,10 @@ abstract class SockAddrUnix extends Struct {
             super.setPath(path);
             sun_len.set(path.length());
         }
-        protected final UTF8String getPathField() {
+        protected UTF8String getPathField() {
             return sun_addr;
         }
-        protected final NumberField getFamilyField() {
+        protected NumberField getFamilyField() {
             return sun_family;
         }
     }
@@ -144,11 +201,11 @@ abstract class SockAddrUnix extends Struct {
         public final Unsigned16 sun_family = new Unsigned16();
         public final UTF8String sun_addr = new UTF8String(ADDR_LENGTH);
 
-        protected final UTF8String getPathField() {
+        protected UTF8String getPathField() {
             return sun_addr;
         }
 
-        protected final NumberField getFamilyField() {
+        protected NumberField getFamilyField() {
             return sun_family;
         }
     }

--- a/src/main/java/jnr/unixsocket/SockAddrUnix.java
+++ b/src/main/java/jnr/unixsocket/SockAddrUnix.java
@@ -18,6 +18,8 @@
 
 package jnr.unixsocket;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import jnr.constants.platform.ProtocolFamily;
 import jnr.ffi.Platform;
 import jnr.ffi.Platform.OS;
@@ -125,7 +127,7 @@ abstract class SockAddrUnix extends Struct {
         if (0 != ba[0]) {
             len -= 1;
         }
-        return new java.lang.String(java.util.Arrays.copyOf(ba, len));
+        return new java.lang.String(java.util.Arrays.copyOf(ba, len), UTF_8);
     }
 
     /**

--- a/src/main/java/jnr/unixsocket/Ucred.java
+++ b/src/main/java/jnr/unixsocket/Ucred.java
@@ -30,15 +30,15 @@ final class Ucred extends Struct {
         super(jnr.ffi.Runtime.getSystemRuntime());
     }
 
-    final pid_t getPidField() {
+    pid_t getPidField() {
         return pid;
     }
 
-    final uid_t getUidField() {
+    uid_t getUidField() {
         return uid;
     }
 
-    final gid_t getGidField() {
+    gid_t getGidField() {
         return gid;
     }
 }

--- a/src/main/java/jnr/unixsocket/UnixDatagramChannel.java
+++ b/src/main/java/jnr/unixsocket/UnixDatagramChannel.java
@@ -84,14 +84,14 @@ public class UnixDatagramChannel extends AbstractNativeDatagramChannel {
         connect(remote);
     }
 
-	@Override
-	public UnixDatagramChannel bind(SocketAddress local) throws IOException {
+    @Override
+    public UnixDatagramChannel bind(SocketAddress local) throws IOException {
         if (null != local && !(local instanceof UnixSocketAddress)) {
             throw new UnsupportedAddressTypeException();
         }
         localAddress = Common.bind(getFD(), (UnixSocketAddress)local);
         return this;
-	}
+    }
 
     public UnixDatagramChannel connect(UnixSocketAddress remote) {
         stateLock.writeLock().lock();
@@ -181,94 +181,94 @@ public class UnixDatagramChannel extends AbstractNativeDatagramChannel {
         return n;
     }
 
-	@Override
-	public DatagramChannel connect(SocketAddress remote) throws IOException {
-		if (remote instanceof UnixSocketAddress) {
-			return connect(((UnixSocketAddress) remote));
-		} else {
-			throw new UnsupportedAddressTypeException();
-		}
-	}
+    @Override
+    public DatagramChannel connect(SocketAddress remote) throws IOException {
+        if (remote instanceof UnixSocketAddress) {
+            return connect(((UnixSocketAddress) remote));
+        } else {
+            throw new UnsupportedAddressTypeException();
+        }
+    }
 
-	@Override
-	public DatagramSocket socket() {
+    @Override
+    public DatagramSocket socket() {
         try {
             return new UnixDatagramSocket(this);
         } catch (SocketException e) {
             throw new NullPointerException("Could not create UnixDatagramSocket");
         }
-	}
-
-	@Override
-	public long write(ByteBuffer[] srcs, int offset, int length)
-			throws IOException {
-		
-		if (state == State.CONNECTED) {
-			return super.write(srcs, offset, length);
-		} else if (state == State.IDLE) {
-			return 0;
-		} else {
-			throw new ClosedChannelException();
-		}
-	}
-
-	@Override
-	public int read(ByteBuffer dst) throws IOException {
-		if (state == State.CONNECTED) {
-			return super.read(dst);
-		} else if (state == State.IDLE) {
-			return 0;
-		} else {
-			throw new ClosedChannelException();
-		}
-	}
-
-	@Override
-	public int write(ByteBuffer src) throws IOException {
-		if (state == State.CONNECTED) {
-			return super.write(src);
-		} else if (state == State.IDLE) {
-			return 0;
-		} else {
-			throw new ClosedChannelException();
-		}
-	}
-	
-
-	@Override
-	public SocketAddress getRemoteAddress() throws IOException {
-		return remoteAddress;
-	}
-
-	@Override
-	public SocketAddress getLocalAddress() throws IOException {
-		return localAddress;
-	}
-
-	@Override
-	public <T> T getOption(java.net.SocketOption<T> name) throws IOException {
-		throw new UnsupportedOperationException("getOption is not supported");
-	}
-
-	@Override
-	public <T> DatagramChannel setOption(java.net.SocketOption<T> name, T value)
-			throws IOException {
-		throw new UnsupportedOperationException("setOption is not supported");
-	}
-
-	@Override
-	public Set<java.net.SocketOption<?>> supportedOptions() {
-		throw new UnsupportedOperationException("supportedOptions is not supported");
-	}
-
-	@Override
-    public MembershipKey join(InetAddress group, NetworkInterface interf) {
-		throw new UnsupportedOperationException("join is not supported");
     }
 
-	@Override
+    @Override
+    public long write(ByteBuffer[] srcs, int offset, int length)
+    throws IOException {
+
+    if (state == State.CONNECTED) {
+        return super.write(srcs, offset, length);
+    } else if (state == State.IDLE) {
+        return 0;
+    } else {
+        throw new ClosedChannelException();
+    }
+    }
+
+    @Override
+    public int read(ByteBuffer dst) throws IOException {
+        if (state == State.CONNECTED) {
+            return super.read(dst);
+        } else if (state == State.IDLE) {
+            return 0;
+        } else {
+            throw new ClosedChannelException();
+        }
+    }
+
+    @Override
+    public int write(ByteBuffer src) throws IOException {
+        if (state == State.CONNECTED) {
+            return super.write(src);
+        } else if (state == State.IDLE) {
+            return 0;
+        } else {
+            throw new ClosedChannelException();
+        }
+    }
+
+
+    @Override
+    public SocketAddress getRemoteAddress() throws IOException {
+        return remoteAddress;
+    }
+
+    @Override
+    public SocketAddress getLocalAddress() throws IOException {
+        return localAddress;
+    }
+
+    @Override
+    public <T> T getOption(java.net.SocketOption<T> name) throws IOException {
+        throw new UnsupportedOperationException("getOption is not supported");
+    }
+
+    @Override
+    public <T> DatagramChannel setOption(java.net.SocketOption<T> name, T value)
+    throws IOException {
+    throw new UnsupportedOperationException("setOption is not supported");
+    }
+
+    @Override
+    public Set<java.net.SocketOption<?>> supportedOptions() {
+        throw new UnsupportedOperationException("supportedOptions is not supported");
+    }
+
+    @Override
+    public MembershipKey join(InetAddress group, NetworkInterface interf) {
+        throw new UnsupportedOperationException("join is not supported");
+    }
+
+    @Override
     public MembershipKey join(InetAddress group, NetworkInterface interf, InetAddress source) {
-		throw new UnsupportedOperationException("join is not supported");
+        throw new UnsupportedOperationException("join is not supported");
     }
 
 }

--- a/src/main/java/jnr/unixsocket/UnixDatagramChannel.java
+++ b/src/main/java/jnr/unixsocket/UnixDatagramChannel.java
@@ -26,7 +26,6 @@ import java.nio.channels.DatagramChannel;
 import java.nio.channels.MembershipKey;
 import java.nio.channels.UnsupportedAddressTypeException;
 
-import java.net.DatagramSocket;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.net.SocketAddress;

--- a/src/main/java/jnr/unixsocket/UnixDatagramChannel.java
+++ b/src/main/java/jnr/unixsocket/UnixDatagramChannel.java
@@ -64,8 +64,8 @@ public class UnixDatagramChannel extends AbstractNativeDatagramChannel {
         int[] sockets = { -1, -1 };
         Native.socketpair(ProtocolFamily.PF_UNIX, Sock.SOCK_DGRAM, 0, sockets);
         return new UnixDatagramChannel[] {
-            new UnixDatagramChannel(sockets[0], State.CONNECTED),
-                new UnixDatagramChannel(sockets[1], State.CONNECTED)
+            new UnixDatagramChannel(sockets[0], State.CONNECTED, true),
+                new UnixDatagramChannel(sockets[1], State.CONNECTED, true)
         };
     }
 
@@ -74,13 +74,14 @@ public class UnixDatagramChannel extends AbstractNativeDatagramChannel {
     }
 
     UnixDatagramChannel(int fd) {
-        this(fd, State.IDLE);
+        this(fd, State.IDLE, false);
     }
 
-    UnixDatagramChannel(int fd, State initialState) {
+    UnixDatagramChannel(int fd, State initialState, boolean initialBoundState) {
         super(fd);
         stateLock.writeLock().lock();
         state = initialState;
+        bound.set(initialBoundState);
         stateLock.writeLock().unlock();
     }
 

--- a/src/main/java/jnr/unixsocket/UnixDatagramChannel.java
+++ b/src/main/java/jnr/unixsocket/UnixDatagramChannel.java
@@ -130,25 +130,6 @@ public class UnixDatagramChannel extends AbstractNativeDatagramChannel {
         return localAddress != null ? localAddress : (localAddress = Common.getsockname(getFD()));
     }
 
-    /**
-     * Retrieves the credentials for this UNIX socket. If this socket channel
-     * is not in a connected state, this method will return null.
-     *
-     * See man unix 7; SCM_CREDENTIALS
-     *
-     * @throws UnsupportedOperationException if the underlying socket library
-     *         doesn't support the SO_PEERCRED option
-     *
-     * @return the credentials of the remote; null if not connected
-     */
-    public final Credentials getCredentials() {
-        if (!isConnected()) {
-            return null;
-        }
-
-        return Credentials.getCredentials(getFD());
-    }
-
     @Override
     public UnixSocketAddress receive(ByteBuffer src) throws IOException {
         UnixSocketAddress remote = new UnixSocketAddress();
@@ -194,7 +175,7 @@ public class UnixDatagramChannel extends AbstractNativeDatagramChannel {
     }
 
     @Override
-    public DatagramSocket socket() {
+    public UnixDatagramSocket socket() {
         try {
             return new UnixDatagramSocket(this);
         } catch (SocketException e) {

--- a/src/main/java/jnr/unixsocket/UnixDatagramChannel.java
+++ b/src/main/java/jnr/unixsocket/UnixDatagramChannel.java
@@ -1,0 +1,317 @@
+/*
+ * Copyright (C) 2016 Fritz Elfert
+ *
+ * This file is part of the JNR project.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jnr.unixsocket;
+
+import java.io.IOException;
+import java.net.Socket;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.SocketAddress;
+import java.net.SocketException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ClosedChannelException;
+import java.nio.channels.DatagramChannel;
+import java.nio.channels.MembershipKey;
+import java.nio.channels.SelectionKey;
+import java.nio.channels.UnsupportedAddressTypeException;
+import java.util.Set;
+
+import jnr.constants.platform.Errno;
+import jnr.constants.platform.ProtocolFamily;
+import jnr.constants.platform.Sock;
+import jnr.constants.platform.SocketLevel;
+import jnr.constants.platform.SocketOption;
+import jnr.enxio.channels.AbstractNativeDatagramChannel;
+import jnr.ffi.*;
+import jnr.ffi.byref.IntByReference;
+
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ * A {@link java.nio.channels.Channel} implementation that uses a native unix socket
+ */
+public class UnixDatagramChannel extends AbstractNativeDatagramChannel {
+    static enum State {
+        UNINITIALIZED,
+        CONNECTED,
+        IDLE,
+    }
+    private State state;
+    private UnixSocketAddress remoteAddress = null;
+    private UnixSocketAddress localAddress = null;
+    private final ReadWriteLock stateLock = new ReentrantReadWriteLock();
+
+    public static final UnixDatagramChannel open() throws IOException {
+        return new UnixDatagramChannel();
+    }
+
+    public static final UnixDatagramChannel[] pair() throws IOException {
+        int[] sockets = { -1, -1 };
+        Native.socketpair(ProtocolFamily.PF_UNIX, Sock.SOCK_DGRAM, 0, sockets);
+        return new UnixDatagramChannel[] {
+            new UnixDatagramChannel(sockets[0]), new UnixDatagramChannel(sockets[1])
+        };
+    }
+
+    private UnixDatagramChannel() throws IOException {
+        this(Native.socket(ProtocolFamily.PF_UNIX, Sock.SOCK_DGRAM, 0));
+    }
+
+    UnixDatagramChannel(int fd) {
+        super(fd);
+        stateLock.writeLock().lock();
+        state = State.IDLE;
+        stateLock.writeLock().unlock();
+    }
+
+    UnixDatagramChannel(int fd, UnixSocketAddress remote) throws IOException {
+        this(fd);
+        connect(remote);
+    }
+
+	@Override
+	public DatagramChannel bind(SocketAddress local) throws IOException {
+        if (!(local instanceof UnixSocketAddress)) {
+            throw new UnsupportedAddressTypeException();
+        }
+        return bind((UnixSocketAddress)local);
+	}
+
+    private UnixDatagramChannel bind(UnixSocketAddress local) throws IOException {
+        SockAddrUnix sa;
+        if (null == local) {
+            // Support bind in anonymous namespace (Linux, OSX >= 10.9, more?)
+            sa = SockAddrUnix.create();
+            sa.setFamily(ProtocolFamily.PF_UNIX);
+            sa.setPath("");
+        } else {
+            sa = local.getStruct();
+        }
+        if (Native.bind(getFD(), sa, sa.length()) < 0) {
+            Errno error = Errno.valueOf(LastError.getLastError(jnr.ffi.Runtime.getSystemRuntime()));
+            throw new IOException(error.toString());
+        }
+        localAddress = getsockname(getFD());
+        return this;
+    }
+
+    public UnixDatagramChannel connect(UnixSocketAddress remote) throws IOException {
+        stateLock.writeLock().lock();
+        remoteAddress = remote;
+        state = State.CONNECTED;
+        stateLock.writeLock().unlock();
+        return this;
+    }
+
+    public UnixDatagramChannel disconnect() throws IOException {
+        stateLock.writeLock().lock();
+        remoteAddress = null;
+        state = State.IDLE;
+        stateLock.writeLock().unlock();
+        return this;
+    }
+
+    public boolean isConnected() {
+        stateLock.readLock().lock();
+        boolean isConnected = state == State.CONNECTED;
+        stateLock.readLock().lock();
+        return isConnected;
+    }
+
+    public final UnixSocketAddress getRemoteSocketAddress() {
+        if (!isConnected()) {
+            return null;
+        }
+        return remoteAddress != null ? remoteAddress : (remoteAddress = getpeername(getFD()));
+    }
+
+    public final UnixSocketAddress getLocalSocketAddress() {
+        return localAddress != null ? localAddress : (localAddress = getsockname(getFD()));
+    }
+
+    /**
+     * Retrieves the credentials for this UNIX socket. If this socket channel
+     * is not in a connected state, this method will return null.
+     *
+     * See man unix 7; SCM_CREDENTIALS
+     *
+     * @throws UnsupportedOperationException if the underlying socket library
+     *         doesn't support the SO_PEERCRED option
+     *
+     * @return the credentials of the remote; null if not connected
+     */
+    public final Credentials getCredentials() {
+        if (!isConnected()) {
+            return null;
+        }
+
+        return Credentials.getCredentials(getFD());
+    }
+
+    @Override
+    public UnixSocketAddress receive(ByteBuffer src) throws IOException {
+        UnixSocketAddress remote = new UnixSocketAddress();
+        int n = Native.recvfrom(getFD(), src, remote.getStruct());
+        if (n < 0) {
+            throw new IOException(Native.getLastErrorString());
+        }
+        return remote;
+    }
+
+    @Override
+    public int send(ByteBuffer src, SocketAddress target) throws IOException {
+        UnixSocketAddress remote = null;
+        if (null == target) {
+            if (isConnected()) {
+                remote = remoteAddress;
+            } else {
+                throw new NullPointerException("Destination address cannot be null on unconnected datagram sockets");
+            }
+        } else {
+            if (!(target instanceof UnixSocketAddress)) {
+                throw new UnsupportedAddressTypeException();
+            }
+            remote = (UnixSocketAddress)target;
+        }
+        SockAddrUnix sa = (null == remote) ? null : remote.getStruct();
+        int addrlen = (null == sa) ? 0 : sa.length();
+        int n = Native.sendto(getFD(), src, sa, addrlen);
+        if (n < 0) {
+            throw new IOException(Native.getLastErrorString());
+        }
+
+        return n;
+    }
+
+    static UnixSocketAddress getpeername(int sockfd) {
+        UnixSocketAddress remote = new UnixSocketAddress();
+        IntByReference len = new IntByReference(remote.getStruct().getMaximumLength());
+
+        if (Native.libc().getpeername(sockfd, remote.getStruct(), len) < 0) {
+            throw new Error(Native.getLastErrorString());
+        }
+
+        return remote;
+    }
+
+    static UnixSocketAddress getsockname(int sockfd) {
+        UnixSocketAddress local = new UnixSocketAddress();
+        IntByReference len = new IntByReference(local.getStruct().getMaximumLength());
+
+        if (Native.libc().getsockname(sockfd, local.getStruct(), len) < 0) {
+            throw new Error(Native.getLastErrorString());
+        }
+
+        return local;
+    }
+
+	@Override
+	public DatagramChannel connect(SocketAddress remote) throws IOException {
+		if (remote instanceof UnixSocketAddress) {
+			return connect(((UnixSocketAddress) remote));
+		} else {
+			throw new UnsupportedAddressTypeException();
+		}
+	}
+
+	@Override
+	public DatagramSocket socket() {
+        try {
+            return new UnixDatagramSocket(this);
+        } catch (SocketException e) {
+        }
+        return null;
+	}
+
+	@Override
+	public long write(ByteBuffer[] srcs, int offset, int length)
+			throws IOException {
+		
+		if (state == State.CONNECTED) {
+			return super.write(srcs, offset, length);
+		} else if (state == State.IDLE) {
+			return 0;
+		} else {
+			throw new ClosedChannelException();
+		}
+	}
+
+	@Override
+	public int read(ByteBuffer dst) throws IOException {
+		if (state == State.CONNECTED) {
+			return super.read(dst);
+		} else if (state == State.IDLE) {
+			return 0;
+		} else {
+			throw new ClosedChannelException();
+		}
+	}
+
+	@Override
+	public int write(ByteBuffer src) throws IOException {
+		if (state == State.CONNECTED) {
+			return super.write(src);
+		} else if (state == State.IDLE) {
+			return 0;
+		} else {
+			throw new ClosedChannelException();
+		}
+	}
+	
+
+	@Override
+	public SocketAddress getRemoteAddress() throws IOException {
+		return remoteAddress;
+	}
+
+	@Override
+	public SocketAddress getLocalAddress() throws IOException {
+		return localAddress;
+	}
+
+	@Override
+	public <T> T getOption(java.net.SocketOption<T> name) throws IOException {
+		throw new UnsupportedOperationException("getOption is not supported");
+	}
+
+	@Override
+	public <T> DatagramChannel setOption(java.net.SocketOption<T> name, T value)
+			throws IOException {
+		throw new UnsupportedOperationException("setOption is not supported");
+	}
+
+	@Override
+	public Set<java.net.SocketOption<?>> supportedOptions() {
+		throw new UnsupportedOperationException(
+				"supportedOptions is not supported");
+	}
+
+	@Override
+    public MembershipKey join(InetAddress group, NetworkInterface interf) {
+		throw new UnsupportedOperationException("join is not supported");
+    }
+
+	@Override
+    public MembershipKey join(InetAddress group, NetworkInterface interf, InetAddress source) {
+		throw new UnsupportedOperationException("join is not supported");
+    }
+
+}

--- a/src/main/java/jnr/unixsocket/UnixDatagramChannel.java
+++ b/src/main/java/jnr/unixsocket/UnixDatagramChannel.java
@@ -88,7 +88,7 @@ public class UnixDatagramChannel extends AbstractNativeDatagramChannel {
     }
 
 	@Override
-	public DatagramChannel bind(SocketAddress local) throws IOException {
+	public UnixDatagramChannel bind(SocketAddress local) throws IOException {
         if (!(local instanceof UnixSocketAddress)) {
             throw new UnsupportedAddressTypeException();
         }
@@ -113,7 +113,7 @@ public class UnixDatagramChannel extends AbstractNativeDatagramChannel {
         return this;
     }
 
-    public UnixDatagramChannel connect(UnixSocketAddress remote) throws IOException {
+    public UnixDatagramChannel connect(UnixSocketAddress remote) {
         stateLock.writeLock().lock();
         remoteAddress = remote;
         state = State.CONNECTED;
@@ -237,8 +237,8 @@ public class UnixDatagramChannel extends AbstractNativeDatagramChannel {
         try {
             return new UnixDatagramSocket(this);
         } catch (SocketException e) {
+            throw new NullPointerException("Could not create UnixDatagramSocket");
         }
-        return null;
 	}
 
 	@Override
@@ -300,8 +300,7 @@ public class UnixDatagramChannel extends AbstractNativeDatagramChannel {
 
 	@Override
 	public Set<java.net.SocketOption<?>> supportedOptions() {
-		throw new UnsupportedOperationException(
-				"supportedOptions is not supported");
+		throw new UnsupportedOperationException("supportedOptions is not supported");
 	}
 
 	@Override

--- a/src/main/java/jnr/unixsocket/UnixDatagramSocket.java
+++ b/src/main/java/jnr/unixsocket/UnixDatagramSocket.java
@@ -79,9 +79,6 @@ public class UnixDatagramSocket extends DatagramSocket {
             if (isBound()) {
                 throw new SocketException("already bound");
             }
-            if (null != local && !(local instanceof UnixSocketAddress)) {
-                throw new UnsupportedAddressTypeException();
-            }
             try {
                 chan.bind(local);
             } catch (IOException e) {

--- a/src/main/java/jnr/unixsocket/UnixDatagramSocket.java
+++ b/src/main/java/jnr/unixsocket/UnixDatagramSocket.java
@@ -25,7 +25,6 @@ import java.net.InetAddress;
 import java.net.SocketAddress;
 import java.net.SocketException;
 import java.net.DatagramSocket;
-import java.nio.channels.Channels;
 import java.nio.channels.DatagramChannel;
 import java.nio.channels.UnsupportedAddressTypeException;
 
@@ -47,7 +46,6 @@ public class UnixDatagramSocket extends DatagramSocket {
      * @throws SocketException if the socket could not be created.
      */
 	UnixDatagramSocket(final UnixDatagramChannel channel) throws SocketException {
-        super(new UnixSocketAddress()); // Avoid DatagamSocket's default constructor
         chan = channel;
 	}
 
@@ -57,35 +55,13 @@ public class UnixDatagramSocket extends DatagramSocket {
      * @throws SocketException if the socket could not be created.
      */
 	public UnixDatagramSocket() throws SocketException {
-        super(new UnixSocketAddress()); // Avoid DatagamSocket's default constructor
         chan = null;
-    }
-
-    /**
-     * Constructs a new bound instance.
-     * @param local The address to bind to.
-     * @throws SocketException if the socket could not be created or bound.
-     */
-    public UnixDatagramSocket(final SocketAddress local) throws SocketException {
-        try {
-            chan = UnixDatagramChannel.open();
-            if (null != local) {
-                if (!(local instanceof UnixSocketAddress)) {
-                    throw new UnsupportedAddressTypeException();
-                }
-                bind(local);
-            }
-        } catch (IOException e) {
-            throw (SocketException)new SocketException().initCause(e);
-        }
     }
 
     @Override
     public void bind(final SocketAddress local) throws SocketException {
-        if (null != local) {
-            if (!(local instanceof UnixSocketAddress)) {
-                throw new UnsupportedAddressTypeException();
-            }
+        if (null != local && !(local instanceof UnixSocketAddress)) {
+            throw new UnsupportedAddressTypeException();
         }
         if (null != chan) {
             try {
@@ -157,7 +133,7 @@ public class UnixDatagramSocket extends DatagramSocket {
         if (null == chan) {
             return false;
         }
-        return (null != chan.getLocalSocketAddress());
+        return null != chan.getLocalSocketAddress();
     }
 
     @Override

--- a/src/main/java/jnr/unixsocket/UnixDatagramSocket.java
+++ b/src/main/java/jnr/unixsocket/UnixDatagramSocket.java
@@ -72,16 +72,16 @@ public class UnixDatagramSocket extends DatagramSocket {
      */
     @Override
     public void bind(final SocketAddress local) throws SocketException {
-        if (isClosed()) {
-            throw new SocketException("Socket is closed");
-        }
-        if (isBound()) {
-            throw new SocketException("already bound");
-        }
-        if (null != local && !(local instanceof UnixSocketAddress)) {
-            throw new UnsupportedAddressTypeException();
-        }
         if (null != chan) {
+            if (isClosed()) {
+                throw new SocketException("Socket is closed");
+            }
+            if (isBound()) {
+                throw new SocketException("already bound");
+            }
+            if (null != local && !(local instanceof UnixSocketAddress)) {
+                throw new UnsupportedAddressTypeException();
+            }
             try {
                 chan.bind(local);
             } catch (IOException e) {
@@ -106,7 +106,7 @@ public class UnixDatagramSocket extends DatagramSocket {
 
     @Override
     public synchronized void close() {
-        if (closed.compareAndSet(false, true) && null != chan) {
+        if (null != chan && closed.compareAndSet(false, true)) {
             try {
                 chan.close();
             } catch (IOException e) {
@@ -186,11 +186,14 @@ public class UnixDatagramSocket extends DatagramSocket {
         if (null == chan) {
             return false;
         }
-        return null != chan.getLocalSocketAddress();
+        return chan.isBound();
     }
 
     @Override
     public boolean isClosed() {
+        if (null == chan) {
+            return false;
+        }
         return closed.get();
     }
 

--- a/src/main/java/jnr/unixsocket/UnixDatagramSocket.java
+++ b/src/main/java/jnr/unixsocket/UnixDatagramSocket.java
@@ -217,11 +217,19 @@ public class UnixDatagramSocket extends DatagramSocket {
      *
      * @throws UnsupportedOperationException if the underlying socket library
      *         doesn't support the SO_PEERCRED option
+     * @throws SocketException if fetching the socket option failed.
      *
-     * @return the credentials of the remote
+     * @return the credentials of the remote; null if not connected
      */
-    public final Credentials getCredentials() {
-        return chan.getCredentials();
+    public final Credentials getCredentials() throws SocketException {
+        if (!chan.isConnected()) {
+            return null;
+        }
+        try {
+            return chan.getOption(UnixSocketOptions.SO_PEERCRED);
+        } catch (IOException e) {
+            throw (SocketException)new SocketException().initCause(e);
+        }
     }
 
     @Override

--- a/src/main/java/jnr/unixsocket/UnixDatagramSocket.java
+++ b/src/main/java/jnr/unixsocket/UnixDatagramSocket.java
@@ -91,30 +91,26 @@ public class UnixDatagramSocket extends DatagramSocket {
     }
 
     @Override
-    public void disconnect() {
-        synchronized (this) {
-            if (isClosed()) {
-                return;
-            }
+    public synchronized void disconnect() {
+        if (isClosed()) {
+            return;
         }
         if (null != chan) {
             try {
                 chan.disconnect();
             } catch (IOException e) {
-                // ignore
+                ignore();
             }
         }
     }
 
     @Override
-    public void close() {
-        if (closed.compareAndSet(false, true)) {
-            if (null != chan) {
-                try {
-                    chan.close();
-                } catch (IOException e) {
-                    // ignore
-                }
+    public synchronized void close() {
+        if (closed.compareAndSet(false, true) && null != chan) {
+            try {
+                chan.close();
+            } catch (IOException e) {
+                ignore();
             }
         }
     }
@@ -308,5 +304,8 @@ public class UnixDatagramSocket extends DatagramSocket {
     @Override
     public synchronized void receive(DatagramPacket p) throws IOException {
         throw new UnsupportedOperationException("receiving DatagramPackets is not supported");
+    }
+
+    private void ignore() {
     }
 }

--- a/src/main/java/jnr/unixsocket/UnixDatagramSocket.java
+++ b/src/main/java/jnr/unixsocket/UnixDatagramSocket.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2016 Fritz Elfert
+ * 
+ * (ported from https://github.com/softprops/unisockets/blob/master/unisockets-core/src/main/scala/Socket.scala)
+ *
+ * This file is part of the JNR project.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
+package jnr.unixsocket;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.SocketAddress;
+import java.net.SocketException;
+import java.net.DatagramSocket;
+import java.nio.channels.Channels;
+import java.nio.channels.DatagramChannel;
+
+class UnixDatagramSocket extends DatagramSocket {
+
+	private final UnixDatagramChannel chan;
+
+	volatile private boolean closed = false;
+
+	public UnixDatagramSocket(UnixDatagramChannel chan) throws SocketException {
+        this.chan = chan;
+	}
+
+	public void bind(SocketAddress addr) {
+		throw new UnsupportedOperationException("bind not supported");
+	}
+
+	@Override
+	public void close() {
+		closed = true;
+	}
+
+	@Override
+	public void connect(SocketAddress addr) {
+		if (addr instanceof UnixSocketAddress) {
+            try {
+			chan.connect((UnixSocketAddress) addr);
+            } catch (IOException e) {
+            }
+		} else {
+			throw new IllegalArgumentException("address of type "
+					+ addr.getClass() + " are not supported. Use "
+					+ UnixSocketAddress.class + " instead");
+		}
+	}
+
+	@Override
+	public DatagramChannel getChannel() {
+		return chan;
+	}
+
+	@Override
+	public InetAddress getInetAddress() {
+		return null;
+	}
+
+	@Override
+	public SocketAddress getLocalSocketAddress() {
+		UnixSocketAddress address = chan.getLocalSocketAddress();
+		if (address != null) {
+			return address;
+		} else {
+			return null;
+		}
+	}
+
+	@Override
+	public SocketAddress getRemoteSocketAddress() {
+		SocketAddress address = chan.getRemoteSocketAddress();
+
+		if (address != null) {
+			return address;
+		} else {
+			return null;
+		}
+	}
+
+	@Override
+	public boolean isBound() {
+		return false;
+	}
+
+	@Override
+	public boolean isClosed() {
+		return closed;
+	}
+
+	@Override
+	public boolean isConnected() {
+		return chan.isConnected();
+	}
+
+	/**
+     * Retrieves the credentials for this UNIX socket. Clients calling this
+     * method will receive the server's credentials, and servers will receive
+     * the client's credentials. User ID, group ID, and PID are supplied.
+     *
+     * See man unix 7; SCM_CREDENTIALS
+     *
+     * @throws UnsupportedOperationException if the underlying socket library
+     *         doesn't support the SO_PEERCRED option
+     *
+     * @return the credentials of the remote
+     */
+    public final Credentials getCredentials() {
+    	return chan.getCredentials();
+    }
+}

--- a/src/main/java/jnr/unixsocket/UnixDatagramSocket.java
+++ b/src/main/java/jnr/unixsocket/UnixDatagramSocket.java
@@ -1,8 +1,6 @@
 /*
  * Copyright (C) 2016 Fritz Elfert
  * 
- * (ported from https://github.com/softprops/unisockets/blob/master/unisockets-core/src/main/scala/Socket.scala)
- *
  * This file is part of the JNR project.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/jnr/unixsocket/UnixDatagramSocket.java
+++ b/src/main/java/jnr/unixsocket/UnixDatagramSocket.java
@@ -36,25 +36,25 @@ import java.nio.channels.UnsupportedAddressTypeException;
  */
 public class UnixDatagramSocket extends DatagramSocket {
 
-	private final UnixDatagramChannel chan;
+    private final UnixDatagramChannel chan;
 
-	volatile private boolean closed = false;
+    volatile private boolean closed = false;
 
     /**
      * Constructs a new instance.
      * @param channel The channel to use.
      * @throws SocketException if the socket could not be created.
      */
-	UnixDatagramSocket(final UnixDatagramChannel channel) throws SocketException {
+    UnixDatagramSocket(final UnixDatagramChannel channel) throws SocketException {
         chan = channel;
-	}
+    }
 
 
     /**
      * Constructs a new unbound instance.
      * @throws SocketException if the socket could not be created.
      */
-	public UnixDatagramSocket() throws SocketException {
+    public UnixDatagramSocket() throws SocketException {
         chan = null;
     }
 

--- a/src/main/java/jnr/unixsocket/UnixDatagramSocket.java
+++ b/src/main/java/jnr/unixsocket/UnixDatagramSocket.java
@@ -47,8 +47,19 @@ public class UnixDatagramSocket extends DatagramSocket {
      * @throws SocketException if the socket could not be created.
      */
 	UnixDatagramSocket(final UnixDatagramChannel channel) throws SocketException {
+        super(new UnixSocketAddress()); // Avoid DatagamSocket's default constructor
         chan = channel;
 	}
+
+
+    /**
+     * Constructs a new unbound instance.
+     * @throws SocketException if the socket could not be created.
+     */
+	public UnixDatagramSocket() throws SocketException {
+        super(new UnixSocketAddress()); // Avoid DatagamSocket's default constructor
+        chan = null;
+    }
 
     /**
      * Constructs a new bound instance.
@@ -76,19 +87,23 @@ public class UnixDatagramSocket extends DatagramSocket {
                 throw new UnsupportedAddressTypeException();
             }
         }
-        try {
-            chan.bind(local);
-        } catch (IOException e) {
-            throw (SocketException)new SocketException().initCause(e);
+        if (null != chan) {
+            try {
+                chan.bind(local);
+            } catch (IOException e) {
+                throw (SocketException)new SocketException().initCause(e);
+            }
         }
     }
 
     @Override
     public void close() {
-        try {
-            chan.close();
-        } catch (IOException e) {
-            // ignore
+        if (null != chan) {
+            try {
+                chan.close();
+            } catch (IOException e) {
+                // ignore
+            }
         }
         closed = true;
     }
@@ -104,7 +119,7 @@ public class UnixDatagramSocket extends DatagramSocket {
 
     @Override
     public void connect(InetAddress addr, int port) {
-		throw new UnsupportedOperationException("connect(InetAddress, int) is not supported");
+        throw new UnsupportedOperationException("connect(InetAddress, int) is not supported");
     }
 
     @Override
@@ -139,6 +154,9 @@ public class UnixDatagramSocket extends DatagramSocket {
 
     @Override
     public boolean isBound() {
+        if (null == chan) {
+            return false;
+        }
         return (null != chan.getLocalSocketAddress());
     }
 

--- a/src/main/java/jnr/unixsocket/UnixServerSocket.java
+++ b/src/main/java/jnr/unixsocket/UnixServerSocket.java
@@ -40,11 +40,11 @@ public class UnixServerSocket {
         return new UnixSocket(channel.accept());
     }
 
-    public void bind(SocketAddress endpoint) throws java.io.IOException {
+    public void bind(SocketAddress endpoint) throws IOException {
         bind(endpoint, 128);
     }
 
-    public void bind(SocketAddress endpoint, int backlog) throws java.io.IOException {
+    public void bind(SocketAddress endpoint, int backlog) throws IOException {
         if (!(endpoint instanceof UnixSocketAddress)) {
             throw new IOException("Invalid address");
         }

--- a/src/main/java/jnr/unixsocket/UnixServerSocket.java
+++ b/src/main/java/jnr/unixsocket/UnixServerSocket.java
@@ -21,6 +21,8 @@ package jnr.unixsocket;
 import java.io.IOException;
 import java.net.SocketAddress;
 
+import java.nio.channels.UnsupportedAddressTypeException;
+
 public class UnixServerSocket {
     final UnixServerSocketChannel channel;
     final int fd;
@@ -45,18 +47,13 @@ public class UnixServerSocket {
     }
 
     public void bind(SocketAddress endpoint, int backlog) throws IOException {
-        if (!(endpoint instanceof UnixSocketAddress)) {
-            throw new IOException("Invalid address");
+        if (null != endpoint && !(endpoint instanceof UnixSocketAddress)) {
+            throw new UnsupportedAddressTypeException();
         }
-        localAddress = (UnixSocketAddress) endpoint;
-
-        if (Native.bind(fd, localAddress.getStruct(), localAddress.length()) < 0) {
-            throw new IOException(Native.getLastErrorString());
-        }
-
+        localAddress = Common.bind(fd, (UnixSocketAddress)endpoint);
         if (Native.listen(fd, backlog) < 0) {
             throw new IOException(Native.getLastErrorString());
         }
     }
-    
+
 }

--- a/src/main/java/jnr/unixsocket/UnixServerSocketChannel.java
+++ b/src/main/java/jnr/unixsocket/UnixServerSocketChannel.java
@@ -51,7 +51,8 @@ public class UnixServerSocketChannel extends NativeServerSocketChannel {
     public UnixSocketChannel accept() throws IOException {
         UnixSocketAddress remote = new UnixSocketAddress();
         SockAddrUnix addr = remote.getStruct();
-        IntByReference len = new IntByReference(addr.getMaximumLength());
+        int maxLength = addr.getMaximumLength();
+        IntByReference len = new IntByReference(maxLength);
 
         int clientfd = Native.accept(getFD(), addr, len);
 
@@ -63,8 +64,8 @@ public class UnixServerSocketChannel extends NativeServerSocketChannel {
             return null;
         }
 
-        // Handle unnamed sockets
-        if (len.getValue() == addr.getHeaderLength()) addr.setPath("");
+        // Handle unnamed sockets and sockets in Linux' abstract namespace
+        addr.updatePath(len.getValue());
 
         // Always force the socket back to blocking mode
         Native.setBlocking(clientfd, true);

--- a/src/main/java/jnr/unixsocket/UnixServerSocketChannel.java
+++ b/src/main/java/jnr/unixsocket/UnixServerSocketChannel.java
@@ -70,7 +70,7 @@ public class UnixServerSocketChannel extends NativeServerSocketChannel {
         // Always force the socket back to blocking mode
         Native.setBlocking(clientfd, true);
 
-        return new UnixSocketChannel(clientfd, remote);
+        return new UnixSocketChannel(clientfd);
     }
 
     public final UnixServerSocket socket() {

--- a/src/main/java/jnr/unixsocket/UnixSocket.java
+++ b/src/main/java/jnr/unixsocket/UnixSocket.java
@@ -26,6 +26,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetAddress;
 import java.net.SocketAddress;
+import java.net.SocketException;
 import java.nio.channels.Channels;
 import java.nio.channels.SocketChannel;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -150,14 +151,14 @@ class UnixSocket extends java.net.Socket {
     public void shutdownInput() throws IOException {
         if (indown.compareAndSet(false, true)) {
             chan.shutdownInput();
-        };        
+        }
     }
 
     @Override
     public void shutdownOutput() throws IOException {
         if (outdown.compareAndSet(false, true)) {
             chan.shutdownOutput();
-        }       
+        }
     }
 
     /**
@@ -175,4 +176,77 @@ class UnixSocket extends java.net.Socket {
     public final Credentials getCredentials() {
         return chan.getCredentials();
     }
+
+    @Override
+    public boolean getKeepAlive() throws SocketException {
+        try {
+            return chan.getOption(UnixSocketOptions.SO_KEEPALIVE).booleanValue();
+        } catch (IOException e) {
+            throw (SocketException)new SocketException().initCause(e);
+        }
+    }
+
+    @Override
+    public int getReceiveBufferSize() throws SocketException {
+        try {
+            return chan.getOption(UnixSocketOptions.SO_RCVBUF).intValue();
+        } catch (IOException e) {
+            throw (SocketException)new SocketException().initCause(e);
+        }
+    }
+
+    @Override
+    public int getSendBufferSize() throws SocketException {
+        try {
+            return chan.getOption(UnixSocketOptions.SO_SNDBUF).intValue();
+        } catch (IOException e) {
+            throw (SocketException)new SocketException().initCause(e);
+        }
+    }
+
+    @Override
+    public int getSoTimeout() throws SocketException {
+        try {
+            return chan.getOption(UnixSocketOptions.SO_RCVTIMEO).intValue();
+        } catch (IOException e) {
+            throw (SocketException)new SocketException().initCause(e);
+        }
+    }
+
+    @Override
+    public void setKeepAlive(boolean on) throws SocketException {
+        try {
+            chan.setOption(UnixSocketOptions.SO_KEEPALIVE, Boolean.valueOf(on));
+        } catch (IOException e) {
+            throw (SocketException)new SocketException().initCause(e);
+        }
+    }
+
+    @Override
+    public void setReceiveBufferSize(int size) throws SocketException {
+        try {
+            chan.setOption(UnixSocketOptions.SO_RCVBUF, Integer.valueOf(size));
+        } catch (IOException e) {
+            throw (SocketException)new SocketException().initCause(e);
+        }
+    }
+
+    @Override
+    public void setSendBufferSize(int size) throws SocketException {
+        try {
+            chan.setOption(UnixSocketOptions.SO_SNDBUF, Integer.valueOf(size));
+        } catch (IOException e) {
+            throw (SocketException)new SocketException().initCause(e);
+        }
+    }
+
+    @Override
+    public void setSoTimeout(int timeout) throws SocketException {
+        try {
+            chan.setOption(UnixSocketOptions.SO_RCVTIMEO, Integer.valueOf(timeout));
+        } catch (IOException e) {
+            throw (SocketException)new SocketException().initCause(e);
+        }
+    }
+
 }

--- a/src/main/java/jnr/unixsocket/UnixSocket.java
+++ b/src/main/java/jnr/unixsocket/UnixSocket.java
@@ -31,7 +31,7 @@ import java.nio.channels.Channels;
 import java.nio.channels.SocketChannel;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-class UnixSocket extends java.net.Socket {
+public class UnixSocket extends java.net.Socket {
 
     private UnixSocketChannel chan;
 
@@ -170,11 +170,19 @@ class UnixSocket extends java.net.Socket {
      *
      * @throws UnsupportedOperationException if the underlying socket library
      *         doesn't support the SO_PEERCRED option
+     * @throws SocketException if fetching the socket option failed.
      *
-     * @return the credentials of the remote
+     * @return the credentials of the remote; null if not connected
      */
-    public final Credentials getCredentials() {
-        return chan.getCredentials();
+    public final Credentials getCredentials() throws SocketException {
+        if (!chan.isConnected()) {
+            return null;
+        }
+        try {
+            return chan.getOption(UnixSocketOptions.SO_PEERCRED);
+        } catch (IOException e) {
+            throw (SocketException)new SocketException().initCause(e);
+        }
     }
 
     @Override

--- a/src/main/java/jnr/unixsocket/UnixSocket.java
+++ b/src/main/java/jnr/unixsocket/UnixSocket.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (C) 2009 Wayne Meissner
  * Copyright (C) 2016 Marcus Linke
  * 
  * (ported from https://github.com/softprops/unisockets/blob/master/unisockets-core/src/main/scala/Socket.scala)
@@ -30,132 +31,132 @@ import java.nio.channels.SocketChannel;
 
 class UnixSocket extends java.net.Socket {
 
-	private UnixSocketChannel chan;
+    private UnixSocketChannel chan;
 
-	volatile private boolean closed = false;
-	volatile private boolean indown = false;
-	volatile private boolean outdown = false;
+    volatile private boolean closed = false;
+    volatile private boolean indown = false;
+    volatile private boolean outdown = false;
 
-	private InputStream in;
-	private OutputStream out;
+    private InputStream in;
+    private OutputStream out;
 
-	public UnixSocket(UnixSocketChannel chan) {
-		this.chan = chan;
-		in = Channels.newInputStream(chan);
-		out = Channels.newOutputStream(chan);
-	}
+    public UnixSocket(UnixSocketChannel chan) {
+        this.chan = chan;
+        in = Channels.newInputStream(chan);
+        out = Channels.newOutputStream(chan);
+    }
 
-	public void bind(SocketAddress addr) {
-		throw new UnsupportedOperationException("bind not supported");
-	}
+    public void bind(SocketAddress addr) {
+        throw new UnsupportedOperationException("bind not supported");
+    }
 
-	@Override
-	public void close() throws IOException {
-		chan.close();
-		closed = true;
-	}
+    @Override
+    public void close() throws IOException {
+        chan.close();
+        closed = true;
+    }
 
-	@Override
-	public void connect(SocketAddress addr) throws IOException {
-		connect(addr, 0);
-	}
+    @Override
+    public void connect(SocketAddress addr) throws IOException {
+        connect(addr, 0);
+    }
 
-	public void connect(SocketAddress addr, Integer timeout) throws IOException {
-		if (addr instanceof UnixSocketAddress) {
-			chan.connect((UnixSocketAddress) addr);
-		} else {
-			throw new IllegalArgumentException("address of type "
-					+ addr.getClass() + " are not supported. Use "
-					+ UnixSocketAddress.class + " instead");
-		}
-	}
+    public void connect(SocketAddress addr, Integer timeout) throws IOException {
+        if (addr instanceof UnixSocketAddress) {
+            chan.connect((UnixSocketAddress) addr);
+        } else {
+            throw new IllegalArgumentException("address of type "
+                    + addr.getClass() + " are not supported. Use "
+                    + UnixSocketAddress.class + " instead");
+        }
+    }
 
-	@Override
-	public SocketChannel getChannel() {
-		return chan;
-	}
+    @Override
+    public SocketChannel getChannel() {
+        return chan;
+    }
 
-	@Override
-	public InetAddress getInetAddress() {
-		return null;
-	}
+    @Override
+    public InetAddress getInetAddress() {
+        return null;
+    }
 
-	public InputStream getInputStream() throws IOException {
-		if (chan.isConnected()) {
-			return in;
-		} else {
-			throw new IOException("not connected");
-		}
-	}
+    public InputStream getInputStream() throws IOException {
+        if (chan.isConnected()) {
+            return in;
+        } else {
+            throw new IOException("not connected");
+        }
+    }
 
-	@Override
-	public SocketAddress getLocalSocketAddress() {
-		UnixSocketAddress address = chan.getLocalSocketAddress();
-		if (address != null) {
-			return address;
-		} else {
-			return null;
-		}
-	}
+    @Override
+    public SocketAddress getLocalSocketAddress() {
+        UnixSocketAddress address = chan.getLocalSocketAddress();
+        if (address != null) {
+            return address;
+        } else {
+            return null;
+        }
+    }
 
-	@Override
-	public OutputStream getOutputStream() throws IOException {
-		if (chan.isConnected()) {
-			return out;
-		} else {
-			throw new IOException("not connected");
-		}
-	}
+    @Override
+    public OutputStream getOutputStream() throws IOException {
+        if (chan.isConnected()) {
+            return out;
+        } else {
+            throw new IOException("not connected");
+        }
+    }
 
-	@Override
-	public SocketAddress getRemoteSocketAddress() {
-		SocketAddress address = chan.getRemoteSocketAddress();
+    @Override
+    public SocketAddress getRemoteSocketAddress() {
+        SocketAddress address = chan.getRemoteSocketAddress();
 
-		if (address != null) {
-			return address;
-		} else {
-			return null;
-		}
-	}
+        if (address != null) {
+            return address;
+        } else {
+            return null;
+        }
+    }
 
-	@Override
-	public boolean isBound() {
-		return false;
-	}
+    @Override
+    public boolean isBound() {
+        return false;
+    }
 
-	@Override
-	public boolean isClosed() {
-		return closed;
-	}
+    @Override
+    public boolean isClosed() {
+        return closed;
+    }
 
-	@Override
-	public boolean isConnected() {
-		return chan.isConnected();
-	}
+    @Override
+    public boolean isConnected() {
+        return chan.isConnected();
+    }
 
-	@Override
-	public boolean isInputShutdown() {
-		return indown;
-	}
+    @Override
+    public boolean isInputShutdown() {
+        return indown;
+    }
 
-	@Override
-	public boolean isOutputShutdown() {
-		return outdown;
-	}
+    @Override
+    public boolean isOutputShutdown() {
+        return outdown;
+    }
 
-	@Override
-	public void shutdownInput() throws IOException {
-		chan.shutdownInput();
-		indown = true;
-	}
+    @Override
+    public void shutdownInput() throws IOException {
+        chan.shutdownInput();
+        indown = true;
+    }
 
-	@Override
-	public void shutdownOutput() throws IOException {
-		chan.shutdownOutput();
-		outdown = true;
-	}
-	
-	/**
+    @Override
+    public void shutdownOutput() throws IOException {
+        chan.shutdownOutput();
+        outdown = true;
+    }
+
+    /**
      * Retrieves the credentials for this UNIX socket. Clients calling this
      * method will receive the server's credentials, and servers will receive
      * the client's credentials. User ID, group ID, and PID are supplied.
@@ -168,6 +169,6 @@ class UnixSocket extends java.net.Socket {
      * @return the credentials of the remote
      */
     public final Credentials getCredentials() {
-    	return chan.getCredentials();
+        return chan.getCredentials();
     }
 }

--- a/src/main/java/jnr/unixsocket/UnixSocket.java
+++ b/src/main/java/jnr/unixsocket/UnixSocket.java
@@ -56,7 +56,7 @@ public class UnixSocket extends java.net.Socket {
     public void close() throws IOException {
         if (closed.compareAndSet(false, true)) {
             chan.close();
-        };
+        }
     }
 
     @Override

--- a/src/main/java/jnr/unixsocket/UnixSocket.java
+++ b/src/main/java/jnr/unixsocket/UnixSocket.java
@@ -53,8 +53,9 @@ class UnixSocket extends java.net.Socket {
 
     @Override
     public void close() throws IOException {
-        chan.close();
-        closed.compareAndSet(false, true);
+        if (closed.compareAndSet(false, true)) {
+            chan.close();
+        };
     }
 
     @Override
@@ -147,14 +148,16 @@ class UnixSocket extends java.net.Socket {
 
     @Override
     public void shutdownInput() throws IOException {
-        chan.shutdownInput();
-        indown.compareAndSet(false, true);
+        if (indown.compareAndSet(false, true)) {
+            chan.shutdownInput();
+        };        
     }
 
     @Override
     public void shutdownOutput() throws IOException {
-        chan.shutdownOutput();
-        outdown.compareAndSet(false, true);
+        if (outdown.compareAndSet(false, true)) {
+            chan.shutdownOutput();
+        }       
     }
 
     /**

--- a/src/main/java/jnr/unixsocket/UnixSocket.java
+++ b/src/main/java/jnr/unixsocket/UnixSocket.java
@@ -1,5 +1,7 @@
 /*
- * Copyright (C) 2009 Wayne Meissner
+ * Copyright (C) 2016 Marcus Linke
+ * 
+ * (ported from https://github.com/softprops/unisockets/blob/master/unisockets-core/src/main/scala/Socket.scala)
  *
  * This file is part of the JNR project.
  *
@@ -15,7 +17,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  * 
- * ported from  https://github.com/softprops/unisockets/blob/master/unisockets-core/src/main/scala/Socket.scala 
  */
 package jnr.unixsocket;
 

--- a/src/main/java/jnr/unixsocket/UnixSocket.java
+++ b/src/main/java/jnr/unixsocket/UnixSocket.java
@@ -14,45 +14,147 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * 
+ * ported from  https://github.com/softprops/unisockets/blob/master/unisockets-core/src/main/scala/Socket.scala 
  */
-
 package jnr.unixsocket;
 
-import jnr.constants.platform.SocketLevel;
-import jnr.constants.platform.SocketOption;
-import jnr.enxio.channels.NativeSocketChannel;
-import jnr.ffi.byref.IntByReference;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.SocketAddress;
+import java.nio.channels.Channels;
+import java.nio.channels.SocketChannel;
 
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.nio.channels.Channel;
+class UnixSocket extends java.net.Socket {
 
-public class UnixSocket {
-    private final NativeSocketChannel channel;
+	private UnixSocketChannel chan;
 
-    UnixSocket(NativeSocketChannel channel) {
-        this.channel = channel;
-    }
+	volatile private boolean closed = false;
+	volatile private boolean indown = false;
+	volatile private boolean outdown = false;
 
-    public final Channel getChannel() {
-        return channel;
-    }
+	private InputStream in;
+	private OutputStream out;
 
-    public final void setKeepAlive(boolean on) {
-        Native.setsockopt(channel.getFD(), SocketLevel.SOL_SOCKET, SocketOption.SO_KEEPALIVE, on);
-    }
+	public UnixSocket(UnixSocketChannel chan) {
+		this.chan = chan;
+		in = Channels.newInputStream(chan);
+		out = Channels.newOutputStream(chan);
+	}
 
-    public final boolean getKeepAlive() {
-        ByteBuffer buf = ByteBuffer.allocate(4);
-        buf.order(ByteOrder.BIG_ENDIAN);
-        IntByReference ref = new IntByReference(4);
+	public void bind(SocketAddress addr) {
+		throw new UnsupportedOperationException("bind not supported");
+	}
 
-        Native.libsocket().getsockopt(channel.getFD(), SocketLevel.SOL_SOCKET.intValue(), SocketOption.SO_KEEPALIVE.intValue(), buf, ref);
+	@Override
+	public void close() throws IOException {
+		chan.close();
+		closed = true;
+	}
 
-        return buf.getInt(0) != 0;
-    }
+	@Override
+	public void connect(SocketAddress addr) throws IOException {
+		connect(addr, 0);
+	}
 
-    /**
+	public void connect(SocketAddress addr, Integer timeout) throws IOException {
+		if (addr instanceof UnixSocketAddress) {
+			chan.connect((UnixSocketAddress) addr);
+		} else {
+			throw new IllegalArgumentException("address of type "
+					+ addr.getClass() + " are not supported. Use "
+					+ UnixSocketAddress.class + " instead");
+		}
+	}
+
+	@Override
+	public SocketChannel getChannel() {
+		return chan;
+	}
+
+	@Override
+	public InetAddress getInetAddress() {
+		return null;
+	}
+
+	public InputStream getInputStream() throws IOException {
+		if (chan.isConnected()) {
+			return in;
+		} else {
+			throw new IOException("not connected");
+		}
+	}
+
+	@Override
+	public SocketAddress getLocalSocketAddress() {
+		UnixSocketAddress address = chan.getLocalSocketAddress();
+		if (address != null) {
+			return address;
+		} else {
+			return null;
+		}
+	}
+
+	@Override
+	public OutputStream getOutputStream() throws IOException {
+		if (chan.isConnected()) {
+			return out;
+		} else {
+			throw new IOException("not connected");
+		}
+	}
+
+	@Override
+	public SocketAddress getRemoteSocketAddress() {
+		SocketAddress address = chan.getRemoteSocketAddress();
+
+		if (address != null) {
+			return address;
+		} else {
+			return null;
+		}
+	}
+
+	@Override
+	public boolean isBound() {
+		return false;
+	}
+
+	@Override
+	public boolean isClosed() {
+		return closed;
+	}
+
+	@Override
+	public boolean isConnected() {
+		return chan.isConnected();
+	}
+
+	@Override
+	public boolean isInputShutdown() {
+		return indown;
+	}
+
+	@Override
+	public boolean isOutputShutdown() {
+		return outdown;
+	}
+
+	@Override
+	public void shutdownInput() throws IOException {
+		chan.shutdownInput();
+		indown = true;
+	}
+
+	@Override
+	public void shutdownOutput() throws IOException {
+		chan.shutdownOutput();
+		outdown = true;
+	}
+	
+	/**
      * Retrieves the credentials for this UNIX socket. Clients calling this
      * method will receive the server's credentials, and servers will receive
      * the client's credentials. User ID, group ID, and PID are supplied.
@@ -65,6 +167,6 @@ public class UnixSocket {
      * @return the credentials of the remote
      */
     public final Credentials getCredentials() {
-        return Credentials.getCredentials(channel.getFD());
+    	return chan.getCredentials();
     }
 }

--- a/src/main/java/jnr/unixsocket/UnixSocketAddress.java
+++ b/src/main/java/jnr/unixsocket/UnixSocketAddress.java
@@ -24,6 +24,15 @@ import java.io.ObjectOutputStream;
 
 import jnr.constants.platform.ProtocolFamily;
 
+/**
+ * This class represents an AF_UNIX-style socket address.
+ * On Linux, it supports the platform-specific abstract name space.
+ * <p>
+ * Using an abstract name space is denoted by the socket path starting with
+ * a NUL byte. Sockets in abstract name space have no entry in the file system.
+ * When linux performs autobind, it constructs the resulting path with a
+ * leading NUL, followed by a unique 5-digit hexadecimal number.
+ */
 public class UnixSocketAddress extends java.net.SocketAddress {
 
     private static final long serialVersionUID = 4821337010221569096L;

--- a/src/main/java/jnr/unixsocket/UnixSocketChannel.java
+++ b/src/main/java/jnr/unixsocket/UnixSocketChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009 Wayne Meissner
+ * Copyright (C) 2016 Marcus Linke
  *
  * This file is part of the JNR project.
  *
@@ -262,12 +262,6 @@ public class UnixSocketChannel extends AbstractNativeSocketChannel {
 	}
 
 	@Override
-	public long read(ByteBuffer[] dsts, int offset, int length)
-			throws IOException {
-		throw new UnsupportedOperationException("read unsupported");
-	}
-
-	@Override
 	public Socket socket() {
 		return new UnixSocket(this);
 	}
@@ -275,16 +269,9 @@ public class UnixSocketChannel extends AbstractNativeSocketChannel {
 	@Override
 	public long write(ByteBuffer[] srcs, int offset, int length)
 			throws IOException {
-
+		
 		if (state == State.CONNECTED) {
-			long result = 0;
-			int index = 0;
-
-			for (index = offset; index < length; index++) {
-				result += write(srcs[index]);
-			}
-
-			return result;
+			return super.write(srcs, offset, length);
 		} else if (state == State.IDLE) {
 			return 0;
 		} else {
@@ -313,4 +300,41 @@ public class UnixSocketChannel extends AbstractNativeSocketChannel {
 			throw new ClosedChannelException();
 		}
 	}
+	
+	/**
+
+	@Override
+	public SocketAddress getRemoteAddress() throws IOException {
+		return remoteAddress;
+	}
+
+	@Override
+	public SocketAddress getLocalAddress() throws IOException {
+		throw new UnsupportedOperationException(
+				"getLocalAddress is not supported");
+	}
+
+	@Override
+	public <T> T getOption(java.net.SocketOption<T> name) throws IOException {
+		throw new UnsupportedOperationException("getOption is not supported");
+	}
+
+	@Override
+	public Set<java.net.SocketOption<?>> supportedOptions() {
+		throw new UnsupportedOperationException(
+				"supportedOptions is not supported");
+	}
+
+	@Override
+	public SocketChannel bind(SocketAddress local) throws IOException {
+		throw new UnsupportedOperationException("bind is not supported");
+	}
+
+	@Override
+	public <T> SocketChannel setOption(java.net.SocketOption<T> name, T value)
+			throws IOException {
+		throw new UnsupportedOperationException("setOption is not supported");
+	}
+	
+	**/
 }

--- a/src/main/java/jnr/unixsocket/UnixSocketChannel.java
+++ b/src/main/java/jnr/unixsocket/UnixSocketChannel.java
@@ -23,7 +23,9 @@ import java.net.Socket;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
+import java.nio.channels.SocketChannel;
 import java.nio.channels.UnsupportedAddressTypeException;
+import java.util.Set;
 
 import jnr.constants.platform.Errno;
 import jnr.constants.platform.ProtocolFamily;
@@ -301,7 +303,6 @@ public class UnixSocketChannel extends AbstractNativeSocketChannel {
 		}
 	}
 	
-	/**
 
 	@Override
 	public SocketAddress getRemoteAddress() throws IOException {
@@ -310,8 +311,7 @@ public class UnixSocketChannel extends AbstractNativeSocketChannel {
 
 	@Override
 	public SocketAddress getLocalAddress() throws IOException {
-		throw new UnsupportedOperationException(
-				"getLocalAddress is not supported");
+		return localAddress;
 	}
 
 	@Override
@@ -335,6 +335,4 @@ public class UnixSocketChannel extends AbstractNativeSocketChannel {
 			throws IOException {
 		throw new UnsupportedOperationException("setOption is not supported");
 	}
-	
-	**/
 }

--- a/src/main/java/jnr/unixsocket/UnixSocketChannel.java
+++ b/src/main/java/jnr/unixsocket/UnixSocketChannel.java
@@ -236,27 +236,6 @@ public class UnixSocketChannel extends AbstractNativeSocketChannel {
         return Credentials.getCredentials(getFD());
     }
 
-    public boolean getKeepAlive() {
-        int ret = Native.getsockopt(getFD(), SocketLevel.SOL_SOCKET,
-                jnr.constants.platform.SocketOption.SO_KEEPALIVE.intValue());
-        return (ret == 1) ? true : false;
-    }
-
-    public void setKeepAlive(boolean on) {
-        Native.setsockopt(getFD(), SocketLevel.SOL_SOCKET,
-                jnr.constants.platform.SocketOption.SO_KEEPALIVE, on);
-    }
-
-    public int getSoTimeout() {
-        return Native.getsockopt(getFD(), SocketLevel.SOL_SOCKET,
-                jnr.constants.platform.SocketOption.SO_RCVTIMEO.intValue());
-    }
-
-    public void setSoTimeout(int timeout) {
-        Native.setsockopt(getFD(), SocketLevel.SOL_SOCKET,
-                jnr.constants.platform.SocketOption.SO_RCVTIMEO, timeout);
-    }
-
     @Override
     public boolean connect(SocketAddress remote) throws IOException {
         if (remote instanceof UnixSocketAddress) {

--- a/src/main/java/jnr/unixsocket/UnixSocketChannel.java
+++ b/src/main/java/jnr/unixsocket/UnixSocketChannel.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (C) 2009 Wayne Meissner
  * Copyright (C) 2016 Marcus Linke
  *
  * This file is part of the JNR project.
@@ -40,275 +41,275 @@ import jnr.ffi.LastError;
  * socket
  */
 public class UnixSocketChannel extends AbstractNativeSocketChannel {
-	enum State {
-		UNINITIALIZED, CONNECTED, IDLE, CONNECTING,
-	}
+    enum State {
+        UNINITIALIZED, CONNECTED, IDLE, CONNECTING,
+    }
 
-	private volatile State state;
-	private UnixSocketAddress remoteAddress = null;
-	private UnixSocketAddress localAddress = null;
+    private volatile State state;
+    private UnixSocketAddress remoteAddress = null;
+    private UnixSocketAddress localAddress = null;
 
-	public static final UnixSocketChannel open() throws IOException {
-		return new UnixSocketChannel();
-	}
+    public static final UnixSocketChannel open() throws IOException {
+        return new UnixSocketChannel();
+    }
 
-	public static final UnixSocketChannel open(UnixSocketAddress remote)
-			throws IOException {
-		UnixSocketChannel channel = new UnixSocketChannel();
+    public static final UnixSocketChannel open(UnixSocketAddress remote)
+        throws IOException {
+        UnixSocketChannel channel = new UnixSocketChannel();
 
-		try {
-			channel.connect(remote);
-		} catch (IOException e) {
-			channel.close();
-			throw e;
-		}
-		return channel;
-	}
+        try {
+            channel.connect(remote);
+        } catch (IOException e) {
+            channel.close();
+            throw e;
+        }
+        return channel;
+    }
 
-	public static final UnixSocketChannel create() throws IOException {
-		return new UnixSocketChannel();
-	}
+    public static final UnixSocketChannel create() throws IOException {
+        return new UnixSocketChannel();
+    }
 
-	public static final UnixSocketChannel[] pair() throws IOException {
-		int[] sockets = { -1, -1 };
-		Native.socketpair(ProtocolFamily.PF_UNIX, Sock.SOCK_STREAM, 0, sockets);
-		return new UnixSocketChannel[] { new UnixSocketChannel(sockets[0]),
-				new UnixSocketChannel(sockets[1]) };
-	}
+    public static final UnixSocketChannel[] pair() throws IOException {
+        int[] sockets = { -1, -1 };
+        Native.socketpair(ProtocolFamily.PF_UNIX, Sock.SOCK_STREAM, 0, sockets);
+        return new UnixSocketChannel[] { new UnixSocketChannel(sockets[0]),
+            new UnixSocketChannel(sockets[1]) };
+    }
 
-	/**
-	 * Create a UnixSocketChannel to wrap an existing file descriptor
-	 * (presumably itself a UNIX socket).
-	 *
-	 * @param fd
-	 *            the file descriptor to wrap
-	 * @return the new UnixSocketChannel instance
-	 */
-	public static final UnixSocketChannel fromFD(int fd) {
-		return new UnixSocketChannel(fd);
-	}
+    /**
+     * Create a UnixSocketChannel to wrap an existing file descriptor
+     * (presumably itself a UNIX socket).
+     *
+     * @param fd
+     *            the file descriptor to wrap
+     * @return the new UnixSocketChannel instance
+     */
+    public static final UnixSocketChannel fromFD(int fd) {
+        return new UnixSocketChannel(fd);
+    }
 
-	private UnixSocketChannel() throws IOException {
-		super(Native.socket(ProtocolFamily.PF_UNIX, Sock.SOCK_STREAM, 0));
-		state = State.IDLE;
-	}
+    private UnixSocketChannel() throws IOException {
+        super(Native.socket(ProtocolFamily.PF_UNIX, Sock.SOCK_STREAM, 0));
+        state = State.IDLE;
+    }
 
-	UnixSocketChannel(int fd) {
-		super(fd);
-		state = State.CONNECTED;
-	}
+    UnixSocketChannel(int fd) {
+        super(fd);
+        state = State.CONNECTED;
+    }
 
-	UnixSocketChannel(int fd, UnixSocketAddress remote) {
-		super(fd);
-		state = State.CONNECTED;
-		remoteAddress = remote;
-	}
+    UnixSocketChannel(int fd, UnixSocketAddress remote) {
+        super(fd);
+        state = State.CONNECTED;
+        remoteAddress = remote;
+    }
 
-	private boolean doConnect(SockAddrUnix remote) throws IOException {
-		if (Native.connect(getFD(), remote, remote.length()) != 0) {
-			Errno error = Errno.valueOf(LastError.getLastError(jnr.ffi.Runtime
-					.getSystemRuntime()));
+    private boolean doConnect(SockAddrUnix remote) throws IOException {
+        if (Native.connect(getFD(), remote, remote.length()) != 0) {
+            Errno error = Errno.valueOf(LastError.getLastError(jnr.ffi.Runtime
+                        .getSystemRuntime()));
 
-			switch (error) {
-			case EAGAIN:
-			case EWOULDBLOCK:
-				return false;
+            switch (error) {
+                case EAGAIN:
+                case EWOULDBLOCK:
+                    return false;
 
-			default:
-				throw new IOException(error.toString());
-			}
-		}
+                default:
+                    throw new IOException(error.toString());
+            }
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	public boolean connect(UnixSocketAddress remote) throws IOException {
-		remoteAddress = remote;
-		if (!doConnect(remoteAddress.getStruct())) {
+    public boolean connect(UnixSocketAddress remote) throws IOException {
+        remoteAddress = remote;
+        if (!doConnect(remoteAddress.getStruct())) {
 
-			state = State.CONNECTING;
-			return false;
+            state = State.CONNECTING;
+            return false;
 
-		} else {
+        } else {
 
-			state = State.CONNECTED;
-			return true;
-		}
-	}
+            state = State.CONNECTED;
+            return true;
+        }
+    }
 
-	public boolean isConnected() {
-		return state == State.CONNECTED;
-	}
+    public boolean isConnected() {
+        return state == State.CONNECTED;
+    }
 
-	public boolean isConnectionPending() {
-		return state == State.CONNECTING;
-	}
+    public boolean isConnectionPending() {
+        return state == State.CONNECTING;
+    }
 
-	public boolean finishConnect() throws IOException {
-		switch (state) {
-		case CONNECTED:
-			return true;
+    public boolean finishConnect() throws IOException {
+        switch (state) {
+            case CONNECTED:
+                return true;
 
-		case CONNECTING:
-			if (!doConnect(remoteAddress.getStruct())) {
-				return false;
-			}
-			state = State.CONNECTED;
-			return true;
+            case CONNECTING:
+                if (!doConnect(remoteAddress.getStruct())) {
+                    return false;
+                }
+                state = State.CONNECTED;
+                return true;
 
-		default:
-			throw new IllegalStateException(
-					"socket is not waiting for connect to complete");
-		}
-	}
+            default:
+                throw new IllegalStateException(
+                        "socket is not waiting for connect to complete");
+        }
+    }
 
-	public final UnixSocketAddress getRemoteSocketAddress() {
-		if (state != State.CONNECTED) {
-			return null;
-		}
+    public final UnixSocketAddress getRemoteSocketAddress() {
+        if (state != State.CONNECTED) {
+            return null;
+        }
 
-		if (remoteAddress != null) {
-			return remoteAddress;
-		} else {
-			remoteAddress = Common.getpeername(getFD());
-			return remoteAddress;
-		}
-	}
+        if (remoteAddress != null) {
+            return remoteAddress;
+        } else {
+            remoteAddress = Common.getpeername(getFD());
+            return remoteAddress;
+        }
+    }
 
-	public final UnixSocketAddress getLocalSocketAddress() {
-		if (localAddress != null) {
-			return localAddress;
-		} else {
-			localAddress = Common.getsockname(getFD());
-			return localAddress;
-		}
-	}
+    public final UnixSocketAddress getLocalSocketAddress() {
+        if (localAddress != null) {
+            return localAddress;
+        } else {
+            localAddress = Common.getsockname(getFD());
+            return localAddress;
+        }
+    }
 
-	/**
-	 * Retrieves the credentials for this UNIX socket. If this socket channel is
-	 * not in a connected state, this method will return null.
-	 *
-	 * See man unix 7; SCM_CREDENTIALS
-	 *
-	 * @throws UnsupportedOperationException
-	 *             if the underlying socket library doesn't support the
-	 *             SO_PEERCRED option
-	 *
-	 * @return the credentials of the remote; null if not connected
-	 */
-	public final Credentials getCredentials() {
-		if (state != State.CONNECTED) {
-			return null;
-		}
+    /**
+     * Retrieves the credentials for this UNIX socket. If this socket channel is
+     * not in a connected state, this method will return null.
+     *
+     * See man unix 7; SCM_CREDENTIALS
+     *
+     * @throws UnsupportedOperationException
+     *             if the underlying socket library doesn't support the
+     *             SO_PEERCRED option
+     *
+     * @return the credentials of the remote; null if not connected
+     */
+    public final Credentials getCredentials() {
+        if (state != State.CONNECTED) {
+            return null;
+        }
 
-		return Credentials.getCredentials(getFD());
-	}
+        return Credentials.getCredentials(getFD());
+    }
 
-	public boolean getKeepAlive() {
-		int ret = Native.getsockopt(getFD(), SocketLevel.SOL_SOCKET,
-				SocketOption.SO_KEEPALIVE.intValue());
-		return (ret == 1) ? true : false;
-	}
+    public boolean getKeepAlive() {
+        int ret = Native.getsockopt(getFD(), SocketLevel.SOL_SOCKET,
+                SocketOption.SO_KEEPALIVE.intValue());
+        return (ret == 1) ? true : false;
+    }
 
-	public void setKeepAlive(boolean on) {
-		Native.setsockopt(getFD(), SocketLevel.SOL_SOCKET,
-				SocketOption.SO_KEEPALIVE, on);
-	}
+    public void setKeepAlive(boolean on) {
+        Native.setsockopt(getFD(), SocketLevel.SOL_SOCKET,
+                SocketOption.SO_KEEPALIVE, on);
+    }
 
-	public int getSoTimeout() {
-		return Native.getsockopt(getFD(), SocketLevel.SOL_SOCKET,
-				SocketOption.SO_RCVTIMEO.intValue());
-	}
+    public int getSoTimeout() {
+        return Native.getsockopt(getFD(), SocketLevel.SOL_SOCKET,
+                SocketOption.SO_RCVTIMEO.intValue());
+    }
 
-	public void setSoTimeout(int timeout) {
-		Native.setsockopt(getFD(), SocketLevel.SOL_SOCKET,
-				SocketOption.SO_RCVTIMEO, timeout);
-	}
+    public void setSoTimeout(int timeout) {
+        Native.setsockopt(getFD(), SocketLevel.SOL_SOCKET,
+                SocketOption.SO_RCVTIMEO, timeout);
+    }
 
-	@Override
-	public boolean connect(SocketAddress remote) throws IOException {
-		if (remote instanceof UnixSocketAddress) {
-			return connect(((UnixSocketAddress) remote));
-		} else {
-			throw new UnsupportedAddressTypeException();
-		}
-	}
+    @Override
+    public boolean connect(SocketAddress remote) throws IOException {
+        if (remote instanceof UnixSocketAddress) {
+            return connect(((UnixSocketAddress) remote));
+        } else {
+            throw new UnsupportedAddressTypeException();
+        }
+    }
 
-	@Override
-	public Socket socket() {
-		return new UnixSocket(this);
-	}
+    @Override
+    public Socket socket() {
+        return new UnixSocket(this);
+    }
 
-	@Override
-	public long write(ByteBuffer[] srcs, int offset, int length)
-			throws IOException {
-		
-		if (state == State.CONNECTED) {
-			return super.write(srcs, offset, length);
-		} else if (state == State.IDLE) {
-			return 0;
-		} else {
-			throw new ClosedChannelException();
-		}
-	}
+    @Override
+    public long write(ByteBuffer[] srcs, int offset, int length)
+    throws IOException {
 
-	@Override
-	public int read(ByteBuffer dst) throws IOException {
-		if (state == State.CONNECTED) {
-			return super.read(dst);
-		} else if (state == State.IDLE) {
-			return 0;
-		} else {
-			throw new ClosedChannelException();
-		}
-	}
+    if (state == State.CONNECTED) {
+        return super.write(srcs, offset, length);
+    } else if (state == State.IDLE) {
+        return 0;
+    } else {
+        throw new ClosedChannelException();
+    }
+    }
 
-	@Override
-	public int write(ByteBuffer src) throws IOException {
-		if (state == State.CONNECTED) {
-			return super.write(src);
-		} else if (state == State.IDLE) {
-			return 0;
-		} else {
-			throw new ClosedChannelException();
-		}
-	}
-	
+    @Override
+    public int read(ByteBuffer dst) throws IOException {
+        if (state == State.CONNECTED) {
+            return super.read(dst);
+        } else if (state == State.IDLE) {
+            return 0;
+        } else {
+            throw new ClosedChannelException();
+        }
+    }
 
-	@Override
-	public SocketAddress getRemoteAddress() throws IOException {
-		return remoteAddress;
-	}
+    @Override
+    public int write(ByteBuffer src) throws IOException {
+        if (state == State.CONNECTED) {
+            return super.write(src);
+        } else if (state == State.IDLE) {
+            return 0;
+        } else {
+            throw new ClosedChannelException();
+        }
+    }
 
-	@Override
-	public SocketAddress getLocalAddress() throws IOException {
-		return localAddress;
-	}
 
-	@Override
-	public <T> T getOption(java.net.SocketOption<T> name) throws IOException {
-		throw new UnsupportedOperationException("getOption is not supported");
-	}
+    @Override
+    public SocketAddress getRemoteAddress() throws IOException {
+        return remoteAddress;
+    }
 
-	@Override
-	public <T> SocketChannel setOption(java.net.SocketOption<T> name, T value)
-			throws IOException {
-		throw new UnsupportedOperationException("setOption is not supported");
-	}
+    @Override
+    public SocketAddress getLocalAddress() throws IOException {
+        return localAddress;
+    }
 
-	@Override
-	public Set<java.net.SocketOption<?>> supportedOptions() {
-		throw new UnsupportedOperationException(
-				"supportedOptions is not supported");
-	}
+    @Override
+    public <T> T getOption(java.net.SocketOption<T> name) throws IOException {
+        throw new UnsupportedOperationException("getOption is not supported");
+    }
 
-	@Override
-	public SocketChannel bind(SocketAddress local) throws IOException {
+    @Override
+    public <T> SocketChannel setOption(java.net.SocketOption<T> name, T value)
+    throws IOException {
+    throw new UnsupportedOperationException("setOption is not supported");
+    }
+
+    @Override
+    public Set<java.net.SocketOption<?>> supportedOptions() {
+        throw new UnsupportedOperationException(
+                "supportedOptions is not supported");
+    }
+
+    @Override
+    public SocketChannel bind(SocketAddress local) throws IOException {
         if (null != local && !(local instanceof UnixSocketAddress)) {
             throw new UnsupportedAddressTypeException();
         }
         localAddress = Common.bind(getFD(), (UnixSocketAddress)local);
         return this;
-	}
+    }
 
 }

--- a/src/main/java/jnr/unixsocket/UnixSocketChannel.java
+++ b/src/main/java/jnr/unixsocket/UnixSocketChannel.java
@@ -216,26 +216,6 @@ public class UnixSocketChannel extends AbstractNativeSocketChannel {
         }
     }
 
-    /**
-     * Retrieves the credentials for this UNIX socket. If this socket channel is
-     * not in a connected state, this method will return null.
-     *
-     * See man unix 7; SCM_CREDENTIALS
-     *
-     * @throws UnsupportedOperationException
-     *             if the underlying socket library doesn't support the
-     *             SO_PEERCRED option
-     *
-     * @return the credentials of the remote; null if not connected
-     */
-    public final Credentials getCredentials() {
-        if (!isConnected()) {
-            return null;
-        }
-
-        return Credentials.getCredentials(getFD());
-    }
-
     @Override
     public boolean connect(SocketAddress remote) throws IOException {
         if (remote instanceof UnixSocketAddress) {
@@ -246,7 +226,7 @@ public class UnixSocketChannel extends AbstractNativeSocketChannel {
     }
 
     @Override
-    public Socket socket() {
+    public UnixSocket socket() {
         return new UnixSocket(this);
     }
 

--- a/src/main/java/jnr/unixsocket/UnixSocketChannel.java
+++ b/src/main/java/jnr/unixsocket/UnixSocketChannel.java
@@ -84,7 +84,7 @@ public class UnixSocketChannel extends AbstractNativeSocketChannel {
 	 * @return the new UnixSocketChannel instance
 	 */
 	public static final UnixSocketChannel fromFD(int fd) {
-		return fromFD(fd);
+		return new UnixSocketChannel(fd);
 	}
 
 	private UnixSocketChannel() throws IOException {

--- a/src/main/java/jnr/unixsocket/UnixSocketChannel.java
+++ b/src/main/java/jnr/unixsocket/UnixSocketChannel.java
@@ -18,243 +18,299 @@
 
 package jnr.unixsocket;
 
+import java.io.IOException;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.channels.ClosedChannelException;
+import java.nio.channels.UnsupportedAddressTypeException;
+
 import jnr.constants.platform.Errno;
 import jnr.constants.platform.ProtocolFamily;
 import jnr.constants.platform.Sock;
 import jnr.constants.platform.SocketLevel;
 import jnr.constants.platform.SocketOption;
-import jnr.enxio.channels.NativeSocketChannel;
-import jnr.ffi.*;
+import jnr.enxio.channels.AbstractNativeSocketChannel;
+import jnr.ffi.LastError;
 import jnr.ffi.byref.IntByReference;
 
-import java.io.IOException;
-import java.nio.channels.SelectionKey;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
-
 /**
- * A {@link java.nio.channels.Channel} implementation that uses a native unix socket
+ * A {@link java.nio.channels.Channel} implementation that uses a native unix
+ * socket
  */
-public class UnixSocketChannel extends NativeSocketChannel {
-    static enum State {
-        UNINITIALIZED,
-        CONNECTED,
-        IDLE,
-        CONNECTING,
-    }
-    private State state;
-    private UnixSocketAddress remoteAddress = null;
-    private UnixSocketAddress localAddress = null;
-    private final ReadWriteLock stateLock = new ReentrantReadWriteLock();
+public class UnixSocketChannel extends AbstractNativeSocketChannel {
+	enum State {
+		UNINITIALIZED, CONNECTED, IDLE, CONNECTING,
+	}
 
-    public static final UnixSocketChannel open() throws IOException {
-        return new UnixSocketChannel();
-    }
+	private volatile State state;
+	private UnixSocketAddress remoteAddress = null;
+	private UnixSocketAddress localAddress = null;
 
-    public static final UnixSocketChannel open(UnixSocketAddress remote) throws IOException {
-        UnixSocketChannel channel = new UnixSocketChannel();
-        try {
-            channel.connect(remote);
-        } catch (IOException e) {
-            channel.close();
-            throw e;
-        }
-        return channel;
-    }
+	public static final UnixSocketChannel open() throws IOException {
+		return new UnixSocketChannel();
+	}
 
-    public static final UnixSocketChannel[] pair() throws IOException {
-        int[] sockets = { -1, -1 };
-        Native.socketpair(ProtocolFamily.PF_UNIX, Sock.SOCK_STREAM, 0, sockets);
-        return new UnixSocketChannel[] {
-            new UnixSocketChannel(sockets[0], SelectionKey.OP_READ | SelectionKey.OP_WRITE),
-            new UnixSocketChannel(sockets[1], SelectionKey.OP_READ | SelectionKey.OP_WRITE)
-        };
-    }
+	public static final UnixSocketChannel open(UnixSocketAddress remote)
+			throws IOException {
+		UnixSocketChannel channel = new UnixSocketChannel();
 
-    /**
-     * Create a UnixSocketChannel to wrap an existing file descriptor (presumably itself a UNIX socket).
-     *
-     * @param fd the file descriptor to wrap
-     * @return the new UnixSocketChannel instance
-     */
-    public static final UnixSocketChannel fromFD(int fd) {
-        return fromFD(fd, SelectionKey.OP_READ | SelectionKey.OP_WRITE);
-    }
+		try {
+			channel.connect(remote);
+		} catch (IOException e) {
+			channel.close();
+			throw e;
+		}
+		return channel;
+	}
 
-    /**
-     * Create a UnixSocketChannel to wrap an existing file descriptor (presumably itself a UNIX socket).
-     *
-     * @param fd the file descriptor to wrap
-     * @param ops the SelectionKey operations the socket supports
-     * @return the new UnixSocketChannel instance
-     */
-    public static final UnixSocketChannel fromFD(int fd, int ops) {
-        return new UnixSocketChannel(fd, ops);
-    }
+	public static final UnixSocketChannel create() throws IOException {
+		return new UnixSocketChannel();
+	}
 
-    private UnixSocketChannel() throws IOException {
-        super(Native.socket(ProtocolFamily.PF_UNIX, Sock.SOCK_STREAM, 0),
-                SelectionKey.OP_CONNECT | SelectionKey.OP_READ | SelectionKey.OP_WRITE);
-        stateLock.writeLock().lock();
-        state = State.IDLE;
-        stateLock.writeLock().unlock();
-    }
+	public static final UnixSocketChannel[] pair() throws IOException {
+		int[] sockets = { -1, -1 };
+		Native.socketpair(ProtocolFamily.PF_UNIX, Sock.SOCK_STREAM, 0, sockets);
+		return new UnixSocketChannel[] { new UnixSocketChannel(sockets[0]),
+				new UnixSocketChannel(sockets[1]) };
+	}
 
-    UnixSocketChannel(int fd, int ops) {
-        super(fd, ops);
-        stateLock.writeLock().lock();
-        state = State.CONNECTED;
-        stateLock.writeLock().unlock();
-    }
+	/**
+	 * Create a UnixSocketChannel to wrap an existing file descriptor
+	 * (presumably itself a UNIX socket).
+	 *
+	 * @param fd
+	 *            the file descriptor to wrap
+	 * @return the new UnixSocketChannel instance
+	 */
+	public static final UnixSocketChannel fromFD(int fd) {
+		return fromFD(fd);
+	}
 
-    UnixSocketChannel(int fd, UnixSocketAddress remote) {
-        super(fd, SelectionKey.OP_READ | SelectionKey.OP_WRITE);
-        stateLock.writeLock().lock();
-        state = State.CONNECTED;
-        stateLock.writeLock().unlock();
-        remoteAddress = remote;
-    }
+	private UnixSocketChannel() throws IOException {
+		super(Native.socket(ProtocolFamily.PF_UNIX, Sock.SOCK_STREAM, 0));
+		state = State.IDLE;
+	}
 
-    private final boolean doConnect(SockAddrUnix remote) throws IOException {
-        if (Native.connect(getFD(), remote, remote.length()) != 0) {
-            Errno error = Errno.valueOf(LastError.getLastError(jnr.ffi.Runtime.getSystemRuntime()));
+	UnixSocketChannel(int fd) {
+		super(fd);
+		state = State.CONNECTED;
+	}
 
-            switch (error) {
-                case EAGAIN:
-                case EWOULDBLOCK:
-                    return false;
+	UnixSocketChannel(int fd, UnixSocketAddress remote) {
+		super(fd);
+		state = State.CONNECTED;
+		remoteAddress = remote;
+	}
 
-                default:
-                    throw new IOException(error.toString());
-            }
-        }
-        return true;
-    }
+	private boolean doConnect(SockAddrUnix remote) throws IOException {
+		if (Native.connect(getFD(), remote, remote.length()) != 0) {
+			Errno error = Errno.valueOf(LastError.getLastError(jnr.ffi.Runtime
+					.getSystemRuntime()));
 
-    public boolean connect(UnixSocketAddress remote) throws IOException {
-        remoteAddress = remote;
-        if (!doConnect(remoteAddress.getStruct())) {
+			switch (error) {
+			case EAGAIN:
+			case EWOULDBLOCK:
+				return false;
 
-            stateLock.writeLock().lock();
-            state = State.CONNECTING;
-            stateLock.writeLock().unlock();
-            return false;
+			default:
+				throw new IOException(error.toString());
+			}
+		}
 
-        } else {
+		return true;
+	}
 
-            stateLock.writeLock().lock();
-            state = State.CONNECTED;
-            stateLock.writeLock().unlock();
-            return true;
-        }
-    }
+	public boolean connect(UnixSocketAddress remote) throws IOException {
+		remoteAddress = remote;
+		if (!doConnect(remoteAddress.getStruct())) {
 
-    public boolean isConnected() {
-        stateLock.readLock().lock();
-        boolean isConnected = state == State.CONNECTED;
-        stateLock.readLock().lock();
-        return isConnected;
-    }
+			state = State.CONNECTING;
+			return false;
 
-    public boolean isConnectionPending() {
-        stateLock.readLock().lock();
-        boolean isConnectionPending = state == State.CONNECTING;
-        stateLock.readLock().lock();
-        return isConnectionPending;
-    }
+		} else {
 
-    public boolean finishConnect() throws IOException {
-        stateLock.writeLock().lock();
-        try {
-            switch (state) {
-                case CONNECTED:
-                    return true;
+			state = State.CONNECTED;
+			return true;
+		}
+	}
 
-                case CONNECTING:
-                    if (!doConnect(remoteAddress.getStruct())) {
-                        return false;
-                    }
-                    state = State.CONNECTED;
-                    return true;
+	public boolean isConnected() {
+		return state == State.CONNECTED;
+	}
 
-                default:
-                    throw new IllegalStateException("socket is not waiting for connect to complete");
-            }
-        } finally {
-            stateLock.writeLock().unlock();
-        }
-    }
+	public boolean isConnectionPending() {
+		return state == State.CONNECTING;
+	}
 
-    public final UnixSocketAddress getRemoteSocketAddress() {
-        if (!isConnected()) {
-            return null;
-        }
-        return remoteAddress != null ? remoteAddress : (remoteAddress = getpeername(getFD()));
-    }
+	public boolean finishConnect() throws IOException {
+		switch (state) {
+		case CONNECTED:
+			return true;
 
-    public final UnixSocketAddress getLocalSocketAddress() {
-        if (!isConnected()) {
-            return null;
-        }
+		case CONNECTING:
+			if (!doConnect(remoteAddress.getStruct())) {
+				return false;
+			}
+			state = State.CONNECTED;
+			return true;
 
-        return localAddress != null ? localAddress : (localAddress = getsockname(getFD()));
-    }
+		default:
+			throw new IllegalStateException(
+					"socket is not waiting for connect to complete");
+		}
+	}
 
-    /**
-     * Retrieves the credentials for this UNIX socket. If this socket channel
-     * is not in a connected state, this method will return null.
-     *
-     * See man unix 7; SCM_CREDENTIALS
-     *
-     * @throws UnsupportedOperationException if the underlying socket library
-     *         doesn't support the SO_PEERCRED option
-     *
-     * @return the credentials of the remote; null if not connected
-     */
-    public final Credentials getCredentials() {
-        if (!isConnected()) {
-            return null;
-        }
+	public final UnixSocketAddress getRemoteSocketAddress() {
+		if (state != State.CONNECTED) {
+			return null;
+		}
 
-        return Credentials.getCredentials(getFD());
-    }
+		if (remoteAddress != null) {
+			return remoteAddress;
+		} else {
+			remoteAddress = getpeername(getFD());
+			return remoteAddress;
+		}
+	}
 
-    static UnixSocketAddress getpeername(int sockfd) {
-        UnixSocketAddress remote = new UnixSocketAddress();
-        IntByReference len = new IntByReference(remote.getStruct().getMaximumLength());
+	public final UnixSocketAddress getLocalSocketAddress() {
+		if (state != State.CONNECTED) {
+			return null;
+		}
 
-        if (Native.libc().getpeername(sockfd, remote.getStruct(), len) < 0) {
-            throw new Error(Native.getLastErrorString());
-        }
+		if (localAddress != null) {
+			return localAddress;
+		} else {
+			localAddress = getsockname(getFD());
+			return localAddress;
+		}
+	}
 
-        return remote;
-    }
+	/**
+	 * Retrieves the credentials for this UNIX socket. If this socket channel is
+	 * not in a connected state, this method will return null.
+	 *
+	 * See man unix 7; SCM_CREDENTIALS
+	 *
+	 * @throws UnsupportedOperationException
+	 *             if the underlying socket library doesn't support the
+	 *             SO_PEERCRED option
+	 *
+	 * @return the credentials of the remote; null if not connected
+	 */
+	public final Credentials getCredentials() {
+		if (state != State.CONNECTED) {
+			return null;
+		}
 
-    static UnixSocketAddress getsockname(int sockfd) {
-        UnixSocketAddress remote = new UnixSocketAddress();
-        IntByReference len = new IntByReference(remote.getStruct().getMaximumLength());
+		return Credentials.getCredentials(getFD());
+	}
 
-        if (Native.libc().getsockname(sockfd, remote.getStruct(), len) < 0) {
-            throw new Error(Native.getLastErrorString());
-        }
+	static UnixSocketAddress getpeername(int sockfd) {
+		UnixSocketAddress remote = new UnixSocketAddress();
+		IntByReference len = new IntByReference(remote.getStruct()
+				.getMaximumLength());
 
-        return remote;
-    }
+		if (Native.libc().getpeername(sockfd, remote.getStruct(), len) < 0) {
+			throw new Error(Native.getLastErrorString());
+		}
 
-    public boolean getKeepAlive() {
-        int ret = Native.getsockopt(getFD(), SocketLevel.SOL_SOCKET, SocketOption.SO_KEEPALIVE.intValue());
-        return (ret == 1) ? true : false;
-    }
+		return remote;
+	}
 
-    public void setKeepAlive(boolean on) {
-        Native.setsockopt(getFD(), SocketLevel.SOL_SOCKET, SocketOption.SO_KEEPALIVE, on);
-    }
+	static UnixSocketAddress getsockname(int sockfd) {
+		UnixSocketAddress remote = new UnixSocketAddress();
+		IntByReference len = new IntByReference(remote.getStruct()
+				.getMaximumLength());
 
-    public int getSoTimeout() {
-        return Native.getsockopt(getFD(), SocketLevel.SOL_SOCKET, SocketOption.SO_RCVTIMEO.intValue());
-    }
+		if (Native.libc().getsockname(sockfd, remote.getStruct(), len) < 0) {
+			throw new Error(Native.getLastErrorString());
+		}
 
-    public void setSoTimeout(int timeout) {
-        Native.setsockopt(getFD(), SocketLevel.SOL_SOCKET, SocketOption.SO_RCVTIMEO, timeout);
-    }
+		return remote;
+	}
+
+	public boolean getKeepAlive() {
+		int ret = Native.getsockopt(getFD(), SocketLevel.SOL_SOCKET,
+				SocketOption.SO_KEEPALIVE.intValue());
+		return (ret == 1) ? true : false;
+	}
+
+	public void setKeepAlive(boolean on) {
+		Native.setsockopt(getFD(), SocketLevel.SOL_SOCKET,
+				SocketOption.SO_KEEPALIVE, on);
+	}
+
+	public int getSoTimeout() {
+		return Native.getsockopt(getFD(), SocketLevel.SOL_SOCKET,
+				SocketOption.SO_RCVTIMEO.intValue());
+	}
+
+	public void setSoTimeout(int timeout) {
+		Native.setsockopt(getFD(), SocketLevel.SOL_SOCKET,
+				SocketOption.SO_RCVTIMEO, timeout);
+	}
+
+	@Override
+	public boolean connect(SocketAddress remote) throws IOException {
+		if (remote instanceof UnixSocketAddress) {
+			return connect(((UnixSocketAddress) remote));
+		} else {
+			throw new UnsupportedAddressTypeException();
+		}
+	}
+
+	@Override
+	public long read(ByteBuffer[] dsts, int offset, int length)
+			throws IOException {
+		throw new UnsupportedOperationException("read unsupported");
+	}
+
+	@Override
+	public Socket socket() {
+		return new UnixSocket(this);
+	}
+
+	@Override
+	public long write(ByteBuffer[] srcs, int offset, int length)
+			throws IOException {
+
+		if (state == State.CONNECTED) {
+			long result = 0;
+			int index = 0;
+
+			for (index = offset; index < length; index++) {
+				result += write(srcs[index]);
+			}
+
+			return result;
+		} else if (state == State.IDLE) {
+			return 0;
+		} else {
+			throw new ClosedChannelException();
+		}
+	}
+
+	@Override
+	public int read(ByteBuffer dst) throws IOException {
+		if (state == State.CONNECTED) {
+			return super.read(dst);
+		} else if (state == State.IDLE) {
+			return 0;
+		} else {
+			throw new ClosedChannelException();
+		}
+	}
+
+	@Override
+	public int write(ByteBuffer src) throws IOException {
+		if (state == State.CONNECTED) {
+			return super.write(src);
+		} else if (state == State.IDLE) {
+			return 0;
+		} else {
+			throw new ClosedChannelException();
+		}
+	}
 }

--- a/src/main/java/jnr/unixsocket/UnixSocketChannel.java
+++ b/src/main/java/jnr/unixsocket/UnixSocketChannel.java
@@ -20,7 +20,6 @@
 package jnr.unixsocket;
 
 import java.io.IOException;
-import java.net.Socket;
 import java.net.SocketAddress;
 import java.net.SocketOption;
 import java.nio.ByteBuffer;
@@ -36,7 +35,6 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import jnr.constants.platform.Errno;
 import jnr.constants.platform.ProtocolFamily;
 import jnr.constants.platform.Sock;
-import jnr.constants.platform.SocketLevel;
 import jnr.enxio.channels.AbstractNativeSocketChannel;
 import jnr.ffi.LastError;
 

--- a/src/main/java/jnr/unixsocket/UnixSocketOptions.java
+++ b/src/main/java/jnr/unixsocket/UnixSocketOptions.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2016 Fritz Elfert
+ *
+ * This file is part of the JNR project.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jnr.unixsocket;
+
+import java.net.SocketOption;
+
+/**
+ * Defines common socket options for AF_UNIX sockets.
+ */
+public final class UnixSocketOptions {
+
+    private static class GenericOption<T> implements SocketOption<T> {
+        private final String name;
+        private final Class<T> type;
+        GenericOption(String name, Class<T> type) {
+            this.name = name;
+            this.type = type;
+        }
+        @Override public String name() { return name; }
+        @Override public Class<T> type() { return type; }
+        @Override public String toString() { return name; }
+    }
+
+    /**
+     * Get/Set size of the socket send buffer.
+     */
+    public static final SocketOption<Integer> SO_SNDBUF =
+        new GenericOption<Integer>("SO_SNDBUF", Integer.class);
+
+    /**
+     * Get/Set send timeout.
+     */
+    public static final SocketOption<Integer> SO_SNDTIMEO =
+        new GenericOption<Integer>("SO_SNDTIMEO", Integer.class);
+
+    /**
+     * Get/Set size of the socket receive buffer.
+     */
+    public static final SocketOption<Integer> SO_RCVBUF =
+        new GenericOption<Integer>("SO_RCVBUF", Integer.class);
+
+    /**
+     * Get/Set receive timeout.
+     */
+    public static final SocketOption<Integer> SO_RCVTIMEO =
+        new GenericOption<Integer>("SO_RCVTIMEO", Integer.class);
+
+    /**
+     * Keep connection alive.
+     */
+    public static final SocketOption<Boolean> SO_KEEPALIVE =
+        new GenericOption<Boolean>("SO_KEEPALIVE", Boolean.class);
+
+    /**
+     * Fetch peer credentials.
+     */
+    public static final SocketOption<Credentials> SO_PEERCRED =
+        new GenericOption<Credentials>("SO_PEERCRED", Credentials.class);
+
+}
+

--- a/src/test/java/jnr/unixsocket/BasicDatagramFunctionalityTest.java
+++ b/src/test/java/jnr/unixsocket/BasicDatagramFunctionalityTest.java
@@ -123,26 +123,23 @@ public class BasicDatagramFunctionalityTest {
         try {
             ch.bind(null);
             fail("Should have thrown AlreadyBoundException");
-        } catch (AlreadyBoundException ex) {
-        }
-        try {
-            ch.socket().bind(null);
-            fail("Should have thrown SocketException");
-        } catch (SocketException ex) {
-            assertEquals("exception message", ex.getMessage(), "already bound");
+        } catch (AlreadyBoundException abx) {
+            try {
+                ch.socket().bind(null);
+                fail("Should have thrown SocketException");
+            } catch (SocketException sx) {
+                assertEquals("exception message", sx.getMessage(), "already bound");
+            }
         }
     }
 
-    // Ignore for now @Test
-    public void socketBufferTest() throws Exception {
-        UnixDatagramChannel ch = UnixDatagramChannel.open();
-        int rxs = ch.getOption(UnixSocketOptions.SO_RCVBUF);
-        int txs = ch.getOption(UnixSocketOptions.SO_SNDBUF);
-        System.out.println(String.format("rxbuf=%d, txbuf=%d", rxs, txs));
-        ch.setOption(UnixSocketOptions.SO_RCVBUF, rxs - 100);
-        ch.setOption(UnixSocketOptions.SO_SNDBUF, txs - 100);
-        rxs = ch.getOption(UnixSocketOptions.SO_RCVBUF);
-        txs = ch.getOption(UnixSocketOptions.SO_SNDBUF);
-        System.out.println(String.format("rxbuf=%d, txbuf=%d", rxs, txs));
+    @Test
+    public void pairTest() throws Exception {
+        UnixDatagramChannel[] sp = UnixDatagramChannel.pair();
+        for (final UnixDatagramChannel ch : sp) {
+            assertTrue("Channel is connected", ch.isConnected());
+            assertTrue("Channel is bound", ch.isBound());
+            assertFalse("Channel's socket is not closed", ch.socket().isClosed());
+        }
     }
 }

--- a/src/test/java/jnr/unixsocket/BasicDatagramFunctionalityTest.java
+++ b/src/test/java/jnr/unixsocket/BasicDatagramFunctionalityTest.java
@@ -18,26 +18,25 @@
  */
 package jnr.unixsocket;
 
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
+import static junit.framework.Assert.fail;
+
 import java.io.File;
 import java.io.IOException;
-import java.net.SocketAddress;
 import java.net.SocketException;
 import java.nio.ByteBuffer;
-import java.nio.CharBuffer;
-import java.nio.file.Files;
 import java.nio.channels.AlreadyBoundException;
 import java.nio.channels.DatagramChannel;
 import java.nio.charset.StandardCharsets;
-
-import java.util.Set;
-
-import org.junit.Assume;
-import org.junit.Test;
+import java.nio.file.Files;
 
 import jnr.ffi.Platform;
 import jnr.ffi.Platform.OS;
 
-import static junit.framework.Assert.*;
+import org.junit.Assume;
+import org.junit.Test;
 
 public class BasicDatagramFunctionalityTest {
     private static final String DATA = "foo bar baz. The quick brown fox jumps over the lazy dog. ";

--- a/src/test/java/jnr/unixsocket/BasicDatagramFunctionalityTest.java
+++ b/src/test/java/jnr/unixsocket/BasicDatagramFunctionalityTest.java
@@ -36,7 +36,11 @@ import java.nio.channels.Selector;
 import java.nio.charset.StandardCharsets;
 import java.util.Set;
 
+import org.junit.Assume;
 import org.junit.Test;
+
+import jnr.ffi.Platform;
+import jnr.ffi.Platform.OS;
 
 import static junit.framework.Assert.*;
 
@@ -111,6 +115,8 @@ public class BasicDatagramFunctionalityTest {
 
     @Test
     public void largeBasicOperationTest() throws Throwable {
+        Assume.assumeTrue(OS.LINUX == Platform.getNativePlatform().getOS());
+
         basicOperation(1000L * DATA.length());
     }
 

--- a/src/test/java/jnr/unixsocket/BasicDatagramFunctionalityTest.java
+++ b/src/test/java/jnr/unixsocket/BasicDatagramFunctionalityTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2016 Fritz Elfert
+ * 
+ * (ported from https://github.com/softprops/unisockets/blob/master/unisockets-core/src/main/scala/Socket.scala)
+ *
+ * This file is part of the JNR project.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
+package jnr.unixsocket;
+
+import jnr.enxio.channels.NativeSelectorProvider;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.SocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.file.Files;
+import java.nio.channels.Channels;
+import java.nio.channels.DatagramChannel;
+import java.nio.channels.SelectionKey;
+import java.nio.channels.Selector;
+import java.nio.charset.StandardCharsets;
+import java.util.Set;
+
+import org.junit.Test;
+
+import static junit.framework.Assert.*;
+
+public class BasicDatagramFunctionalityTest {
+    private static final String DATA = "foo bar baz. The quick brown fox jumps over the lazy dog. ";
+    volatile Throwable serverException;
+    volatile long received = 0;
+
+    private UnixSocketAddress makeAddress() throws IOException {
+        File socketFile = Files.createTempFile("jnr-unixsocket-test", ".sock").toFile();
+        socketFile.delete();
+        socketFile.deleteOnExit();
+        return new UnixSocketAddress(socketFile);
+    }
+
+    private void basicOperation(final long minBytesToSend) throws Throwable {
+        serverException = null;
+        final StringBuffer rxdata = new StringBuffer();
+        final StringBuffer txdata = new StringBuffer();
+        final ByteBuffer rxbuf = ByteBuffer.allocate(1024);
+        final ByteBuffer txbuf = ByteBuffer.allocate(2024);
+        final UnixSocketAddress serverAddress = makeAddress();
+
+        Thread serverThread = new Thread("server side") {
+            final UnixDatagramChannel serverChannel = UnixDatagramChannel.open().bind(serverAddress);
+
+            public void run() {
+                while (null == serverException) {
+                    try {
+                        rxbuf.clear();
+                        SocketAddress from = serverChannel.receive(rxbuf);
+                        rxbuf.flip();
+                        int count = rxbuf.limit();
+                        rxdata.append(StandardCharsets.UTF_8.decode(rxbuf).toString());
+                        received += count;;
+                    } catch (IOException ex) {
+                        serverException = ex;
+                    }
+                }
+            }
+        };
+        serverThread.start();
+
+        // client logic
+        DatagramChannel clientChannel = UnixDatagramChannel.open();
+        received = 0;
+        long written = 0;
+        while (null == serverException && written < minBytesToSend) {
+            txbuf.put(StandardCharsets.UTF_8.encode(DATA));
+            txbuf.flip();
+            written += clientChannel.send(txbuf, serverAddress);
+            txbuf.compact();
+            txdata.append(DATA);
+            if (null != serverException) {
+                throw new Exception().initCause(serverException);
+            }
+        }
+        clientChannel.close();
+        while (null == serverException && received < written) {
+            Thread.sleep(100);
+        }
+
+        assertTrue("More than 0 bytes written", written > 0);
+        assertEquals("received", written, received);
+        assertEquals("received data", txdata.toString(), rxdata.toString());
+    }
+
+    @Test
+    public void smallBasicOperationTest() throws Throwable {
+        basicOperation(DATA.length());
+    }
+
+    @Test
+    public void largeBasicOperationTest() throws Throwable {
+        basicOperation(1000L * DATA.length());
+    }
+
+}

--- a/src/test/java/jnr/unixsocket/BasicDatagramFunctionalityTest.java
+++ b/src/test/java/jnr/unixsocket/BasicDatagramFunctionalityTest.java
@@ -133,7 +133,7 @@ public class BasicDatagramFunctionalityTest {
         }
     }
 
-    @Test
+    // Ignore for now @Test
     public void socketBufferTest() throws Exception {
         UnixDatagramChannel ch = UnixDatagramChannel.open();
         int rxs = ch.getOption(UnixSocketOptions.SO_RCVBUF);

--- a/src/test/java/jnr/unixsocket/BasicDatagramFunctionalityTest.java
+++ b/src/test/java/jnr/unixsocket/BasicDatagramFunctionalityTest.java
@@ -71,7 +71,7 @@ public class BasicDatagramFunctionalityTest {
                 while (null == serverException) {
                     try {
                         rxbuf.clear();
-                        SocketAddress from = serverChannel.receive(rxbuf);
+                        serverChannel.receive(rxbuf);
                         rxbuf.flip();
                         int count = rxbuf.limit();
                         rxdata.append(StandardCharsets.UTF_8.decode(rxbuf).toString());

--- a/src/test/java/jnr/unixsocket/BasicDatagramFunctionalityTest.java
+++ b/src/test/java/jnr/unixsocket/BasicDatagramFunctionalityTest.java
@@ -1,8 +1,6 @@
 /*
  * Copyright (C) 2016 Fritz Elfert
  * 
- * (ported from https://github.com/softprops/unisockets/blob/master/unisockets-core/src/main/scala/Socket.scala)
- *
  * This file is part of the JNR project.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/jnr/unixsocket/BasicFunctionalityTest.java
+++ b/src/test/java/jnr/unixsocket/BasicFunctionalityTest.java
@@ -15,6 +15,8 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import org.junit.Test;
 
 import static junit.framework.Assert.*;
@@ -69,9 +71,9 @@ public class BasicFunctionalityTest {
 
         assertEquals(ADDRESS, channel2.getRemoteSocketAddress());
 
-        Channels.newOutputStream(channel2).write(DATA.getBytes());
+        Channels.newOutputStream(channel2).write(DATA.getBytes(UTF_8));
 
-        InputStreamReader r = new InputStreamReader(Channels.newInputStream(channel2));
+        InputStreamReader r = new InputStreamReader(Channels.newInputStream(channel2), UTF_8);
         CharBuffer result = CharBuffer.allocate(1024);
         r.read(result);
 

--- a/src/test/java/jnr/unixsocket/ChannelOptionsTest.java
+++ b/src/test/java/jnr/unixsocket/ChannelOptionsTest.java
@@ -18,27 +18,13 @@
  */
 package jnr.unixsocket;
 
-import java.io.File;
-import java.io.IOException;
-import java.net.SocketAddress;
-import java.net.SocketException;
-import java.nio.ByteBuffer;
-import java.nio.CharBuffer;
-import java.nio.file.Files;
-import java.nio.channels.AlreadyBoundException;
-import java.nio.channels.DatagramChannel;
-import java.nio.charset.StandardCharsets;
-
-import java.util.Set;
-
-import org.junit.Assume;
-import org.junit.Ignore;
-import org.junit.Test;
+import static junit.framework.Assert.*;
 
 import jnr.ffi.Platform;
 import jnr.ffi.Platform.OS;
 
-import static junit.framework.Assert.*;
+import org.junit.Assume;
+import org.junit.Test;
 
 public class ChannelOptionsTest {
 

--- a/src/test/java/jnr/unixsocket/ChannelOptionsTest.java
+++ b/src/test/java/jnr/unixsocket/ChannelOptionsTest.java
@@ -1,8 +1,6 @@
 /*
  * Copyright (C) 2016 Fritz Elfert
  * 
- * (ported from https://github.com/softprops/unisockets/blob/master/unisockets-core/src/main/scala/Socket.scala)
- *
  * This file is part of the JNR project.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -131,17 +129,22 @@ public class ChannelOptionsTest {
     }
 
     @Test
-    @Ignore
-    // Linux doubles the values when setting. Check what other platforms do.
+    // Linux doubles the values when setting.
+    // OSX keeps settings consistent but restricts possible values to a multiple of 256
+    // Check what other platforms do.
     public void socketBufferTest() throws Exception {
         UnixDatagramChannel ch = UnixDatagramChannel.open();
         int rxs = ch.getOption(UnixSocketOptions.SO_RCVBUF);
         int txs = ch.getOption(UnixSocketOptions.SO_SNDBUF);
+        assertTrue("receive buffer size >= 256", rxs >= 256);
+        assertTrue("send buffer size >= 256", txs >= 256);
+        /*
         System.out.println(String.format("rxbuf=%d, txbuf=%d", rxs, txs));
         ch.setOption(UnixSocketOptions.SO_RCVBUF, rxs - 100);
         ch.setOption(UnixSocketOptions.SO_SNDBUF, txs - 100);
         rxs = ch.getOption(UnixSocketOptions.SO_RCVBUF);
         txs = ch.getOption(UnixSocketOptions.SO_SNDBUF);
         System.out.println(String.format("rxbuf=%d, txbuf=%d", rxs, txs));
+        */
     }
 }

--- a/src/test/java/jnr/unixsocket/ChannelOptionsTest.java
+++ b/src/test/java/jnr/unixsocket/ChannelOptionsTest.java
@@ -46,6 +46,8 @@ public class ChannelOptionsTest {
 
     @Test
     public void readonlyDatagramChannelOptionTest() throws Exception {
+        Assume.assumeTrue(OS.LINUX == Platform.getNativePlatform().getOS());
+
         UnixDatagramChannel[] sp = UnixDatagramChannel.pair();
         UnixDatagramChannel ch = sp[0];
         Credentials c = ch.socket().getCredentials();
@@ -60,6 +62,8 @@ public class ChannelOptionsTest {
 
     @Test
     public void readonlySocketChannelOptionTest() throws Exception {
+        Assume.assumeTrue(OS.LINUX == Platform.getNativePlatform().getOS());
+
         UnixSocketChannel[] sp = UnixSocketChannel.pair();
         UnixSocketChannel ch = sp[0];
         Credentials c = ch.socket().getCredentials();

--- a/src/test/java/jnr/unixsocket/ChannelOptionsTest.java
+++ b/src/test/java/jnr/unixsocket/ChannelOptionsTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2016 Fritz Elfert
+ * 
+ * (ported from https://github.com/softprops/unisockets/blob/master/unisockets-core/src/main/scala/Socket.scala)
+ *
+ * This file is part of the JNR project.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
+package jnr.unixsocket;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.SocketAddress;
+import java.net.SocketException;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.file.Files;
+import java.nio.channels.AlreadyBoundException;
+import java.nio.channels.DatagramChannel;
+import java.nio.charset.StandardCharsets;
+
+import java.util.Set;
+
+import org.junit.Assume;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import jnr.ffi.Platform;
+import jnr.ffi.Platform.OS;
+
+import static junit.framework.Assert.*;
+
+public class ChannelOptionsTest {
+
+    @Test
+    public void readonlyDatagramChannelOptionTest() throws Exception {
+        UnixDatagramChannel[] sp = UnixDatagramChannel.pair();
+        UnixDatagramChannel ch = sp[0];
+        Credentials c = ch.socket().getCredentials();
+        try {
+            // SO_PEERCRED is readonly
+            ch.setOption(UnixSocketOptions.SO_PEERCRED, c);
+            fail("Should have thrown AssertionError");
+        } catch (AssertionError ae) {
+            assertEquals("exception message", ae.getMessage(), "Option not found or not writable");
+        }
+    }
+
+    @Test
+    public void readonlySocketChannelOptionTest() throws Exception {
+        UnixSocketChannel[] sp = UnixSocketChannel.pair();
+        UnixSocketChannel ch = sp[0];
+        Credentials c = ch.socket().getCredentials();
+        try {
+            // SO_PEERCRED is readonly
+            ch.setOption(UnixSocketOptions.SO_PEERCRED, c);
+            fail("Should have thrown AssertionError");
+        } catch (AssertionError ae) {
+            assertEquals("exception message", ae.getMessage(), "Option not found or not writable");
+        }
+    }
+
+    @Test
+    public void unsupportedChannelOptionTest() throws Exception {
+        UnixDatagramChannel ch = UnixDatagramChannel.open();
+        try {
+            // SO_KEEPALIVE is suitable only for SOCK_STREAM sockets
+            ch.getOption(UnixSocketOptions.SO_KEEPALIVE);
+            fail("Should have thrown UnsupportedOperationException");
+        } catch (UnsupportedOperationException uoe) {
+            assertEquals("exception message", uoe.getMessage(), "'SO_KEEPALIVE' not supported");
+        }
+    }
+
+    @Test
+    public void keepaliveOptionTest() throws Exception {
+        UnixSocketChannel ch = UnixSocketChannel.open();
+        boolean origValue = ch.getOption(UnixSocketOptions.SO_KEEPALIVE).booleanValue();
+        assertEquals("Initial value of SO_KEEPALIVE", origValue, false);
+        ch.setOption(UnixSocketOptions.SO_KEEPALIVE, Boolean.TRUE);
+        boolean changedValue = ch.getOption(UnixSocketOptions.SO_KEEPALIVE).booleanValue();
+        assertEquals("Changed value of SO_KEEPALIVE", changedValue, true);
+        ch.setOption(UnixSocketOptions.SO_KEEPALIVE, Boolean.FALSE);
+        changedValue = ch.getOption(UnixSocketOptions.SO_KEEPALIVE).booleanValue();
+        assertEquals("Changed value of SO_KEEPALIVE", changedValue, origValue);
+    }
+
+    @Test
+    public void invalidOptionValueTest() throws Exception {
+        UnixSocketChannel ch = UnixSocketChannel.open();
+        try {
+            ch.setOption(UnixSocketOptions.SO_RCVTIMEO, Integer.valueOf(-1));
+            fail("Should have thrown IllegalArgumentException");
+        } catch (IllegalArgumentException iae) {
+            assertEquals("exception message", iae.getMessage(), "Invalid send/receive timeout");
+        }
+        try {
+            ch.setOption(UnixSocketOptions.SO_SNDTIMEO, Integer.valueOf(-1));
+            fail("Should have thrown IllegalArgumentException");
+        } catch (IllegalArgumentException iae) {
+            assertEquals("exception message", iae.getMessage(), "Invalid send/receive timeout");
+        }
+        try {
+            ch.setOption(UnixSocketOptions.SO_RCVBUF, Integer.valueOf(-1));
+            fail("Should have thrown IllegalArgumentException");
+        } catch (IllegalArgumentException iae) {
+            assertEquals("exception message", iae.getMessage(), "Invalid send/receive buffer size");
+        }
+        try {
+            ch.setOption(UnixSocketOptions.SO_SNDBUF, Integer.valueOf(-1));
+            fail("Should have thrown IllegalArgumentException");
+        } catch (IllegalArgumentException iae) {
+            assertEquals("exception message", iae.getMessage(), "Invalid send/receive buffer size");
+        }
+    }
+
+    @Test
+    @Ignore
+    // Linux doubles the values when setting. Check what other platforms do.
+    public void socketBufferTest() throws Exception {
+        UnixDatagramChannel ch = UnixDatagramChannel.open();
+        int rxs = ch.getOption(UnixSocketOptions.SO_RCVBUF);
+        int txs = ch.getOption(UnixSocketOptions.SO_SNDBUF);
+        System.out.println(String.format("rxbuf=%d, txbuf=%d", rxs, txs));
+        ch.setOption(UnixSocketOptions.SO_RCVBUF, rxs - 100);
+        ch.setOption(UnixSocketOptions.SO_SNDBUF, txs - 100);
+        rxs = ch.getOption(UnixSocketOptions.SO_RCVBUF);
+        txs = ch.getOption(UnixSocketOptions.SO_SNDBUF);
+        System.out.println(String.format("rxbuf=%d, txbuf=%d", rxs, txs));
+    }
+}

--- a/src/test/java/jnr/unixsocket/CredentialsFunctionalTest.java
+++ b/src/test/java/jnr/unixsocket/CredentialsFunctionalTest.java
@@ -102,7 +102,7 @@ public class CredentialsFunctionalTest {
     public int getCurrentPid() {
         String[] nameParts = ManagementFactory.getRuntimeMXBean().getName().split("@", 2);
         assertEquals("Cannot determine PID", 2, nameParts.length);
-        return Integer.valueOf(nameParts[0]);
+        return Integer.parseInt(nameParts[0]);
     }
 
     /*
@@ -124,6 +124,6 @@ public class CredentialsFunctionalTest {
             fr.close();
         }
 
-        return Integer.valueOf(uidText.toString());
+        return Integer.parseInt(uidText.toString());
     }
 }

--- a/src/test/java/jnr/unixsocket/CredentialsFunctionalTest.java
+++ b/src/test/java/jnr/unixsocket/CredentialsFunctionalTest.java
@@ -71,7 +71,7 @@ public class CredentialsFunctionalTest {
         assertNotNull("Client socket must be non-null.", client);
         assertNotNull("Server socket must be non-null.", server);
 
-        Credentials clientCreds = client.getCredentials();
+        Credentials clientCreds = client.socket().getCredentials();
         Credentials serverCreds = server.getCredentials();
 
         int myPid = getCurrentPid();

--- a/src/test/java/jnr/unixsocket/CredentialsFunctionalTest.java
+++ b/src/test/java/jnr/unixsocket/CredentialsFunctionalTest.java
@@ -87,6 +87,16 @@ public class CredentialsFunctionalTest {
         //don't have an easy way of getting effective GID, but they should be the same
         assertEquals("Client/server running in same process, GID should be the same",
                 clientCreds.getGid(), serverCreds.getGid());
+
+        // Verify, that results from new interface are the same
+        Credentials newCreds = client.getOption(UnixSocketOptions.SO_PEERCRED);
+        assertNotNull(newCreds);
+        assertEquals("Current PID should match new API PID",
+                myPid, newCreds.getPid());
+        assertEquals("old/new API results (UID) should be the same",
+                clientCreds.getUid(), newCreds.getUid());
+        assertEquals("old/new API results (GID) should be the same",
+                clientCreds.getGid(), newCreds.getGid());
     }
 
     public int getCurrentPid() {

--- a/src/test/java/jnr/unixsocket/ForFDTest.java
+++ b/src/test/java/jnr/unixsocket/ForFDTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 
 import java.io.File;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotNull;
@@ -37,7 +38,7 @@ public class ForFDTest {
 
                     try {
                         channel = server.accept();
-                        channel.write(ByteBuffer.wrap(FOOBAR.getBytes()));
+                        channel.write(ByteBuffer.wrap(FOOBAR.getBytes(StandardCharsets.UTF_8)));
                     } catch (Exception e) {
                         serverException = e;
                     } finally {

--- a/src/test/java/jnr/unixsocket/UnixDatagramChannelTest.java
+++ b/src/test/java/jnr/unixsocket/UnixDatagramChannelTest.java
@@ -1,5 +1,9 @@
 package jnr.unixsocket;
 
+import java.io.File;
+import java.nio.file.Files;
+import java.util.regex.Pattern;
+
 import org.junit.Test;
 import org.junit.Assume;
 
@@ -30,6 +34,20 @@ public class UnixDatagramChannelTest {
         // see http://man7.org/linux/man-pages/man7/unix.7.html
         final String RE = "^\\000([0-9a-f]){5}$";
 
+        UnixDatagramChannel ch = UnixDatagramChannel.open();
+        ch.bind(null);
+        UnixSocketAddress a = ch.getLocalSocketAddress();
+        assertTrue("socket path pattern matches " + RE, a.path().matches(RE));
+    }
+
+    @Test
+    public void testAutobindEmulation() throws Exception {
+        Assume.assumeTrue(OS.LINUX != Platform.getNativePlatform().getOS());
+
+        File f = Files.createTempFile("jnr-unixsocket-tmp", ".end").toFile();
+        f.delete();
+        String path = f.getPath().replaceAll("-tmp.*\\.end", "-tmp");
+        final String RE = "^" + Pattern.quote(path) + ".*\\.sock$";
         UnixDatagramChannel ch = UnixDatagramChannel.open();
         ch.bind(null);
         UnixSocketAddress a = ch.getLocalSocketAddress();

--- a/src/test/java/jnr/unixsocket/UnixDatagramChannelTest.java
+++ b/src/test/java/jnr/unixsocket/UnixDatagramChannelTest.java
@@ -8,11 +8,11 @@ import static junit.framework.Assert.*;
 import jnr.ffi.Platform;
 import jnr.ffi.Platform.OS;
 
-public class UnixSocketChannelTest {
+public class UnixDatagramChannelTest {
 
     @Test
     public void testForUnnamedSockets() throws Exception {
-        UnixSocketChannel[] sp = UnixSocketChannel.pair();
+        UnixDatagramChannel[] sp = UnixDatagramChannel.pair();
 
         // getpeername check
         assertEquals("remote socket path", "", sp[0].getRemoteSocketAddress().path());
@@ -30,7 +30,7 @@ public class UnixSocketChannelTest {
         // see http://man7.org/linux/man-pages/man7/unix.7.html
         final String RE = "^\\000([0-9a-f]){5}$";
 
-        UnixSocketChannel ch = UnixSocketChannel.open();
+        UnixDatagramChannel ch = UnixDatagramChannel.open();
         ch.bind(null);
         UnixSocketAddress a = ch.getLocalSocketAddress();
         assertTrue("socket path pattern matches " + RE, a.path().matches(RE));
@@ -43,7 +43,7 @@ public class UnixSocketChannelTest {
         final String ABSTRACT = "\000foobarbaz";
 
         UnixSocketAddress a = new UnixSocketAddress(ABSTRACT);
-        UnixSocketChannel ch = UnixSocketChannel.open();
+        UnixDatagramChannel ch = UnixDatagramChannel.open();
         ch.bind(a);
         assertEquals("local socket path", ABSTRACT, ch.getLocalSocketAddress().path());
     }

--- a/src/test/java/jnr/unixsocket/example/LocalSyslogClient.java
+++ b/src/test/java/jnr/unixsocket/example/LocalSyslogClient.java
@@ -22,8 +22,12 @@ import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
+
 import jnr.unixsocket.UnixSocketAddress;
 import jnr.unixsocket.UnixDatagramChannel;
+
+import jnr.ffi.Platform;
+import jnr.ffi.Platform.OS;
 
 import java.lang.management.ManagementFactory;
 
@@ -103,8 +107,7 @@ public class LocalSyslogClient {
     }
 
     private String getSocketPath() {
-        String uname = System.getProperty("os.name");
-        if (uname.equalsIgnoreCase("Mac OS X")) {
+        if (Platform.getNativePlatform().getOS() == OS.DARWIN) {
             return "/var/run/syslog";
         }
         return "/dev/log";

--- a/src/test/java/jnr/unixsocket/example/LocalSyslogClient.java
+++ b/src/test/java/jnr/unixsocket/example/LocalSyslogClient.java
@@ -113,7 +113,7 @@ public class LocalSyslogClient {
         return "/dev/log";
     }
 
-    public int getPID() {
+    private int getPid() {
         String[] nameParts = ManagementFactory.getRuntimeMXBean().getName().split("@", 2);
         if (2 == nameParts.length) {
             return Integer.parseInt(nameParts[0]);
@@ -129,7 +129,7 @@ public class LocalSyslogClient {
         UnixSocketAddress address = new UnixSocketAddress(path);
         UnixDatagramChannel channel = UnixDatagramChannel.open();
         int pri = makePri(Priority.LOG_WARNING, Facility.LOG_DAEMON);
-        int pid = getPID();
+        int pid = getPid();
         String tag = "whatever";
         if (args.length > 0) {
             formatLine(pri, tag, pid, args);

--- a/src/test/java/jnr/unixsocket/example/LocalSyslogClient.java
+++ b/src/test/java/jnr/unixsocket/example/LocalSyslogClient.java
@@ -1,0 +1,146 @@
+/*
+ * This file is part of the JNR project.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jnr.unixsocket.example;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+import jnr.unixsocket.UnixSocketAddress;
+import jnr.unixsocket.UnixDatagramChannel;
+
+import java.lang.management.ManagementFactory;
+
+public class LocalSyslogClient {
+
+    private StringBuffer line = new StringBuffer();
+    private SimpleDateFormat sdf = new SimpleDateFormat("MMM dd HH:mm:ss", Locale.US);
+
+
+    private String formatDate() {
+        synchronized(this) {
+            return sdf.format(new Date());
+        }
+    }
+
+    private void formatLine(final int pri, final String tag, final int pid, final String[] args) {
+        line.setLength(0);
+        line.append(String.format("<%d>", pri))
+            .append(formatDate())
+            .append(" ")
+            .append(tag);
+        if (0 < pid) {
+            line.append(String.format("[%d]", pid));
+        }
+        line.append(":");
+        for (String arg : args) {
+            line.append(" ").append(arg);
+        }
+    }
+
+    private enum Priority {
+        LOG_EMERG,
+        LOG_ALERT,
+        LOG_CRIT,
+        LOG_ERR,
+        LOG_WARNING,
+        LOG_NOTICE,
+        LOG_INFO,
+        LOG_DEBUG;
+    }
+
+    private enum Facility {
+        LOG_KERN(0 << 3),
+        LOG_USER(1 << 3),
+        LOG_MAIL(2 << 3),
+        LOG_DAEMON(3 << 3),
+        LOG_AUTH(4 << 3),
+        LOG_SYSLOG(5 << 3),
+        LOG_LPR(6 << 3),
+        LOG_NEWS(7 << 3),
+        LOG_UUCP(8 << 3),
+        LOG_CRON(9 << 3),
+        LOG_AUTHPRIV(10 << 3),
+        LOG_FTP(11 << 3),
+        LOG_LOCAL0(16 << 3),
+        LOG_LOCAL1(17 << 3),
+        LOG_LOCAL2(18 << 3),
+        LOG_LOCAL3(19 << 3),
+        LOG_LOCAL4(20 << 3),
+        LOG_LOCAL5(21 << 3),
+        LOG_LOCAL6(22 << 3),
+        LOG_LOCAL7(23 << 3);
+
+        private int myValue;
+
+        Facility(int value) {
+            myValue = value;
+        }
+
+        public int getValue() {
+            return myValue;
+        }
+    }
+
+    private int makePri(Priority priority, Facility facility) {
+        return priority.ordinal() | facility.getValue();
+    }
+
+    private String getSocketPath() {
+        String uname = System.getProperty("os.name");
+        if (uname.equalsIgnoreCase("Mac OS X")) {
+            return "/var/run/syslog";
+        }
+        return "/dev/log";
+    }
+
+    public int getPID() {
+        String[] nameParts = ManagementFactory.getRuntimeMXBean().getName().split("@", 2);
+        if (2 == nameParts.length) {
+            return Integer.parseInt(nameParts[0]);
+        }
+        return 0;
+    }
+
+    private void doit(String[] args) throws IOException, InterruptedException {
+        java.io.File path = new java.io.File(getSocketPath());
+        if (!path.exists()) {
+            throw new IOException(String.format("%s does not exist", path.getAbsolutePath()));
+        }
+        UnixSocketAddress address = new UnixSocketAddress(path);
+        UnixDatagramChannel channel = UnixDatagramChannel.open();
+        int pri = makePri(Priority.LOG_WARNING, Facility.LOG_DAEMON);
+        int pid = getPID();
+        String tag = "whatever";
+        if (args.length > 0) {
+            formatLine(pri, tag, pid, args);
+            ByteBuffer buf = ByteBuffer.wrap(line.toString().getBytes(StandardCharsets.UTF_8));
+            channel.send(buf, address);
+        } else {
+            formatLine(pri, tag, pid, new String[]{"The quick brown fox jumps\nover the lazy dog"});
+            ByteBuffer buf = ByteBuffer.wrap(line.toString().getBytes(StandardCharsets.UTF_8));
+            channel.send(buf, address);
+        }
+    }
+
+    public static void main(String[] args) throws IOException, InterruptedException {
+        LocalSyslogClient client = new LocalSyslogClient();
+        client.doit(args);
+    }
+}

--- a/src/test/java/jnr/unixsocket/example/UnixServer.java
+++ b/src/test/java/jnr/unixsocket/example/UnixServer.java
@@ -46,11 +46,11 @@ public class UnixServer {
 
             while (sel.select() > 0) {
                 Set<SelectionKey> keys = sel.selectedKeys();
-		Iterator<SelectionKey> iterator = keys.iterator();
+                Iterator<SelectionKey> iterator = keys.iterator();
                 boolean running = false;
                 boolean cancelled = false;
-		while ( iterator.hasNext()  ) {
-		    SelectionKey k = iterator.next();
+                while ( iterator.hasNext()  ) {
+                    SelectionKey k = iterator.next();
                     Actor a = (Actor) k.attachment();
                     if (a.rxready()) {
                         running = true;
@@ -58,7 +58,7 @@ public class UnixServer {
                         k.cancel();
                         cancelled = true;
                     }
-		    iterator.remove();
+                    iterator.remove();
                 }
                 if (!running && cancelled) {
                     System.out.println("No Actors Running any more");


### PR DESCRIPTION
This is a work-in-progress PR that refactors UnixSocketChannel to extend java.nio.channels.SocketChannel as well as implement a UnixDatagramChannel that extends java.nio.channels.DatagramChannel by @felfert. The goal is to extract common base classes for both channel implementations.
