### PR TITLE
Add missing unlocks to UnixSocketChannel

### DIFF
--- a/src/main/java/jnr/unixsocket/UnixSocketChannel.java
+++ b/src/main/java/jnr/unixsocket/UnixSocketChannel.java
@@ -32,8 +32,6 @@ import java.nio.channels.SelectionKey;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
-import static jnr.unixsocket.SockAddrUnix.HEADER_LENGTH;
-
 /**
  * A {@link java.nio.channels.Channel} implementation that uses a native unix socket
  */
@@ -154,14 +152,14 @@ public class UnixSocketChannel extends NativeSocketChannel {
     public boolean isConnected() {
         stateLock.readLock().lock();
         boolean isConnected = state == State.CONNECTED;
-        stateLock.readLock().lock();
+        stateLock.readLock().unlock();
         return isConnected;
     }
 
     public boolean isConnectionPending() {
         stateLock.readLock().lock();
         boolean isConnectionPending = state == State.CONNECTING;
-        stateLock.readLock().lock();
+        stateLock.readLock().unlock();
         return isConnectionPending;
     }
 

--- a/src/test/java/jnr/unixsocket/UnixSocketChannelTest.java
+++ b/src/test/java/jnr/unixsocket/UnixSocketChannelTest.java
@@ -16,5 +16,12 @@ public class UnixSocketChannelTest {
         // getsockname check
         assertEquals(sp[0].getLocalSocketAddress().path(), "");
         assertEquals(sp[1].getLocalSocketAddress().path(), "");
+
+        assertFalse(sp[0].isConnectionPending());
+        assertFalse(sp[1].isConnectionPending());
+
+        // triggers an infinite wait when the read lock was not released
+        assertTrue(sp[0].finishConnect());
+        assertTrue(sp[1].finishConnect());
     }
 }


### PR DESCRIPTION
A bug was introduced in #30 in UnixSocketChannel#isConnected
and UnixSocketChannel#isConnectionPending preventing the read
lock from being released.
    
 - unlock the read lock in UnixSocketChannel#isConnected
- unlock the read lock in UnixSocketChannel#isConnectionPending
 - add a test that verifies the write lock can be acquired