### PR TITLE
Handle EAGAIN/EWOULDBLOCK in a special way

### DIFF
--- a/src/main/java/jnr/enxio/channels/Common.java
+++ b/src/main/java/jnr/enxio/channels/Common.java
@@ -101,7 +101,13 @@ final class Common {
         int n = Native.write(_fd, buffer);
 
         if (n < 0) {
-            throw new IOException(Native.getLastErrorString());
+            switch (Native.getLastError()) {
+                case EAGAIN:
+                case EWOULDBLOCK:
+                    return 0;
+            default:
+                throw new IOException(Native.getLastErrorString());
+            }
         }
 
         return n;


### PR DESCRIPTION
https://github.com/jruby/jruby/issues/3799#issuecomment-276085335

Return 0 if write failed with EAGAIN/EWOULDBLOCK error.
See https://github.com/jnr/jnr-enxio/pull/23

P.S. In the meantime I have a strong feeling that duplicating jnr-enxio code in jnr-unixsocket is not ideal thing. Is it so different that needs to be put here?