### PR TITLE
Fix deadlock bug in UnixDatagramChannel

### DIFF
--- a/src/main/java/jnr/unixsocket/UnixDatagramChannel.java
+++ b/src/main/java/jnr/unixsocket/UnixDatagramChannel.java
@@ -117,7 +117,7 @@ public class UnixDatagramChannel extends AbstractNativeDatagramChannel {
     public boolean isConnected() {
         stateLock.readLock().lock();
         boolean isConnected = state == State.CONNECTED;
-        stateLock.readLock().lock();
+        stateLock.readLock().unlock();
         return isConnected;
     }
 


### PR DESCRIPTION
## What
When calling `isConnected` on the `UnixDatagramChannel` we are hitting a deadlock.