### PR TITLE
Recover src ByteBuffer when it is invoked EAGAIN/EWOULDBLOCK

### DIFF
--- a/src/main/java/jnr/enxio/channels/Common.java
+++ b/src/main/java/jnr/enxio/channels/Common.java
@@ -124,7 +124,11 @@ final class Common {
         int index = 0;
 
         for (index = offset; index < length; index++) {
-            result += write(srcs[index]);
+            int wanted = srcs[index].remaining();
+            int n = write(srcs[index]);
+            result += n;
+            if (wanted != n)
+                break;
         }
 
         return result;

--- a/src/main/java/jnr/enxio/channels/Common.java
+++ b/src/main/java/jnr/enxio/channels/Common.java
@@ -127,8 +127,9 @@ final class Common {
             int wanted = srcs[index].remaining();
             int n = write(srcs[index]);
             result += n;
-            if (wanted != n)
+            if (wanted != n) {
                 break;
+            }
         }
 
         return result;

--- a/src/main/java/jnr/enxio/channels/Common.java
+++ b/src/main/java/jnr/enxio/channels/Common.java
@@ -92,11 +92,13 @@ final class Common {
 
     int write(ByteBuffer src) throws IOException {
 
+        int pos = src.position();
         ByteBuffer buffer = ByteBuffer.allocate(src.remaining());
 
         buffer.put(src);
 
         buffer.position(0);
+        src.position(pos);
 
         int n = Native.write(_fd, buffer);
 
@@ -108,6 +110,8 @@ final class Common {
             default:
                 throw new IOException(Native.getLastErrorString());
             }
+        } else if (n > 0) {
+            src.position(pos + n);
         }
 
         return n;


### PR DESCRIPTION
When it is invoked EAGAIN/EWOULDBLOCK, caller lost data. so jnr-unixsocket have to recover src ByteBuffer.