### PR TITLE
upgrade jnr-ffi version to support arm64 arch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-ffi</artifactId>
-      <version>2.1.4</version>
+      <version>2.1.9</version>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
jnr-ffi version 2.1.9 benefits from arm64 support.