### PR TITLE
Add missing @Override annotations to UnixSocket

### DIFF
--- a/src/main/java/jnr/unixsocket/UnixSocket.java
+++ b/src/main/java/jnr/unixsocket/UnixSocket.java
@@ -81,6 +81,7 @@ public class UnixSocket extends java.net.Socket {
         connect(addr, 0);
     }
 
+    @Override
     public void connect(SocketAddress addr, Integer timeout) throws IOException {
         if (addr instanceof UnixSocketAddress) {
             chan.connect((UnixSocketAddress) addr);
@@ -101,6 +102,7 @@ public class UnixSocket extends java.net.Socket {
         return null;
     }
 
+    @Override
     public InputStream getInputStream() throws IOException {
         if (chan.isConnected()) {
             return in;

--- a/src/main/java/jnr/unixsocket/UnixSocket.java
+++ b/src/main/java/jnr/unixsocket/UnixSocket.java
@@ -82,7 +82,7 @@ public class UnixSocket extends java.net.Socket {
     }
 
     @Override
-    public void connect(SocketAddress addr, Integer timeout) throws IOException {
+    public void connect(SocketAddress addr, int timeout) throws IOException {
         if (addr instanceof UnixSocketAddress) {
             chan.connect((UnixSocketAddress) addr);
         } else {


### PR DESCRIPTION
Hi there! First time contributor here. Please let me know if this change makes sense! Otherwise, I'm curious why the connect method accepts an Integer rather than an int.

Thank you!