### PR TITLE
Added support for SO_PASSCRED

### DIFF
--- a/src/main/java/jnr/unixsocket/Common.java
+++ b/src/main/java/jnr/unixsocket/Common.java
@@ -157,6 +157,8 @@ final class Common {
         wMap.put(UnixSocketOptions.SO_RCVTIMEO, jnr.constants.platform.SocketOption.SO_RCVTIMEO);
         wMap.put(UnixSocketOptions.SO_SNDTIMEO, jnr.constants.platform.SocketOption.SO_SNDTIMEO);
         wMap.put(UnixSocketOptions.SO_KEEPALIVE, jnr.constants.platform.SocketOption.SO_KEEPALIVE);
+        wMap.put(UnixSocketOptions.SO_PASSCRED, jnr.constants.platform.SocketOption.SO_PASSCRED);
+        
         rMap.putAll(wMap);
         rMap.put(UnixSocketOptions.SO_PEERCRED, jnr.constants.platform.SocketOption.SO_PEERCRED);
     }

--- a/src/main/java/jnr/unixsocket/UnixSocketChannel.java
+++ b/src/main/java/jnr/unixsocket/UnixSocketChannel.java
@@ -287,6 +287,7 @@ public class UnixSocketChannel extends AbstractNativeSocketChannel {
             set.add(UnixSocketOptions.SO_RCVTIMEO);
             set.add(UnixSocketOptions.SO_PEERCRED);
             set.add(UnixSocketOptions.SO_KEEPALIVE);
+            set.add(UnixSocketOptions.SO_PASSCRED);
             return Collections.unmodifiableSet(set);
         }
     }

--- a/src/main/java/jnr/unixsocket/UnixSocketOptions.java
+++ b/src/main/java/jnr/unixsocket/UnixSocketOptions.java
@@ -73,5 +73,11 @@ public final class UnixSocketOptions {
     public static final SocketOption<Credentials> SO_PEERCRED =
         new GenericOption<Credentials>("SO_PEERCRED", Credentials.class);
 
+    /**
+     * Enable credential transmission.
+     */
+    public static final SocketOption<Boolean> SO_PASSCRED =
+        new GenericOption<Boolean>("SO_PASSCRED", Boolean.class);
+
 }
 


### PR DESCRIPTION
This PR adds support for the SO_PASSCRED flag to allow passing credentials on the socket (e.g. required for DBus)