### PR TITLE
Fixes #69 - Gather writes are broken.

### DIFF
--- a/src/main/java/jnr/unixsocket/impl/Common.java
+++ b/src/main/java/jnr/unixsocket/impl/Common.java
@@ -121,14 +121,18 @@ final class Common {
         return n;
     }
 
-    long write(ByteBuffer[] srcs, int offset, int length)
-        throws IOException {
+    long write(ByteBuffer[] srcs, int offset, int length) throws IOException {
 
         long result = 0;
-        int index = 0;
 
-        for (index = offset; index < length; index++) {
-            result += write(srcs[index]);
+        for (int index = offset; index < length; ++index) {
+            ByteBuffer buffer = srcs[index];
+            int remaining = buffer.remaining();
+            int written = write(buffer);
+            result += written;
+            if (written < remaining) {
+                break;
+            }
         }
 
         return result;

--- a/src/main/java/jnr/unixsocket/impl/Common.java
+++ b/src/main/java/jnr/unixsocket/impl/Common.java
@@ -128,7 +128,14 @@ final class Common {
         for (int index = offset; index < length; ++index) {
             ByteBuffer buffer = srcs[index];
             int remaining = buffer.remaining();
-            int written = write(buffer);
+            int written = 0;
+            while (true) {
+                int w = write(buffer);
+                written += w;
+                if (w == 0 || written == remaining) {
+                    break;
+                }
+            }
             result += written;
             if (written < remaining) {
                 break;


### PR DESCRIPTION
Correctly looping over the buffers, returning
as soon as one of the writes is not complete.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>