### PR TITLE
Use NativeException instead of more general IOException

### DIFF
--- a/src/main/java/jnr/unixsocket/impl/AbstractNativeSocketChannel.java
+++ b/src/main/java/jnr/unixsocket/impl/AbstractNativeSocketChannel.java
@@ -26,6 +26,7 @@ import java.nio.channels.spi.SelectorProvider;
 
 import jnr.constants.platform.Shutdown;
 import jnr.enxio.channels.Native;
+import jnr.enxio.channels.NativeException;
 import jnr.enxio.channels.NativeSelectableChannel;
 import jnr.enxio.channels.NativeSelectorProvider;
 
@@ -85,7 +86,7 @@ public abstract class AbstractNativeSocketChannel extends SocketChannel
     public SocketChannel shutdownInput() throws IOException {
         int n = Native.shutdown(common.getFD(), SHUT_RD);
         if (n < 0) {
-            throw new IOException(Native.getLastErrorString());
+            throw new NativeException(Native.getLastErrorString(), Native.getLastError());
         }
         return this;
     }
@@ -94,7 +95,7 @@ public abstract class AbstractNativeSocketChannel extends SocketChannel
     public SocketChannel shutdownOutput() throws IOException {
         int n = Native.shutdown(common.getFD(), SHUT_WR);
         if (n < 0) {
-            throw new IOException(Native.getLastErrorString());
+            throw new NativeException(Native.getLastErrorString(), Native.getLastError());
         }
         return this;
     }

--- a/src/main/java/jnr/unixsocket/impl/Common.java
+++ b/src/main/java/jnr/unixsocket/impl/Common.java
@@ -23,6 +23,7 @@ import java.nio.ByteBuffer;
 
 import jnr.constants.platform.Errno;
 import jnr.enxio.channels.Native;
+import jnr.enxio.channels.NativeException;
 
 /**
  * Helper class, providing common methods.
@@ -65,7 +66,7 @@ final class Common {
                         return 0;
 
                     default:
-                        throw new IOException(Native.getLastErrorString());
+                        throw new NativeException(Native.getLastErrorString(), lastError);
                 }
 
             default: {
@@ -108,13 +109,14 @@ final class Common {
                 src.position(src.position()-(r-n));
             }
         } else {
-            switch (Native.getLastError()) {
+            Errno lastError = Native.getLastError();
+            switch (lastError) {
                 case EAGAIN:
                 case EWOULDBLOCK:
                     src.position(src.position()-r);
                     return 0;
             default:
-                throw new IOException(Native.getLastErrorString());
+                throw new NativeException(Native.getLastErrorString(), lastError);
             }
         }
 


### PR DESCRIPTION
To allow users of library to see an error code (errno) in exceptions, use NativeException instead of more general IOException.