### PR TITLE
fix: Build by moving from findbugs to spotbugs and removing Java 7 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: java
 jdk:
-  - openjdk7
   - openjdk8
   - openjdk9
 notifications:

--- a/pom.xml
+++ b/pom.xml
@@ -109,12 +109,20 @@
         </executions>
       </plugin>
 
-      <!-- run findbugs check -->
+      <!-- run spotbugs check -->
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <version>3.0.3</version>
-        <executions>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <version>3.1.12.2</version>
+        <dependencies>
+          <!-- overwrite dependency on spotbugs if you want to specify the version of spotbugs -->
+          <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs</artifactId>
+            <version>4.0.0-beta4</version>
+          </dependency>
+        </dependencies>
+         <executions>
           <execution>
             <phase>process-test-classes</phase>
             <goals>
@@ -124,9 +132,9 @@
         </executions>
         <configuration>
           <effort>Max</effort>
-          <includeTests>true</includeTests>
-          <threshold>Low</threshold>
-          <xmlOutput>true</xmlOutput>
+          <includeTests>false</includeTests>
+          <relaxed>true</relaxed>
+          <spotbugsXmlOutput>true</spotbugsXmlOutput>
           <failOnError>false</failOnError>
         </configuration>
       </plugin>

--- a/src/main/java/jnr/unixsocket/UnixDatagramChannel.java
+++ b/src/main/java/jnr/unixsocket/UnixDatagramChannel.java
@@ -87,9 +87,12 @@ public class UnixDatagramChannel extends AbstractNativeDatagramChannel {
     UnixDatagramChannel(int fd, State initialState, boolean initialBoundState) {
         super(fd);
         stateLock.writeLock().lock();
-        state = initialState;
-        bindHandler = new BindHandler(initialBoundState);
-        stateLock.writeLock().unlock();
+        try {
+            state = initialState;
+            bindHandler = new BindHandler(initialBoundState);
+        } finally {
+            stateLock.writeLock().unlock();
+        }
     }
 
     UnixDatagramChannel(int fd, UnixSocketAddress remote) throws IOException {

--- a/src/main/java/jnr/unixsocket/UnixSocket.java
+++ b/src/main/java/jnr/unixsocket/UnixSocket.java
@@ -117,12 +117,7 @@ public class UnixSocket extends java.net.Socket {
 
     @Override
     public SocketAddress getLocalSocketAddress() {
-        UnixSocketAddress address = chan.getLocalSocketAddress();
-        if (address != null) {
-            return address;
-        } else {
-            return null;
-        }
+        return chan.getLocalSocketAddress();
     }
 
     @Override

--- a/src/main/java/jnr/unixsocket/UnixSocketChannel.java
+++ b/src/main/java/jnr/unixsocket/UnixSocketChannel.java
@@ -80,7 +80,7 @@ public class UnixSocketChannel extends AbstractNativeSocketChannel {
     public static final UnixSocketChannel[] pair() throws IOException {
         int[] sockets = { -1, -1 };
         Native.socketpair(ProtocolFamily.PF_UNIX, Sock.SOCK_STREAM, 0, sockets);
-        return new UnixSocketChannel[] { 
+        return new UnixSocketChannel[] {
                 new UnixSocketChannel(sockets[0], State.CONNECTED, true),
                 new UnixSocketChannel(sockets[1], State.CONNECTED, true) };
     }
@@ -100,7 +100,7 @@ public class UnixSocketChannel extends AbstractNativeSocketChannel {
     UnixSocketChannel() throws IOException {
         this(Native.socket(ProtocolFamily.PF_UNIX, Sock.SOCK_STREAM, 0));
     }
-    
+
     UnixSocketChannel(int fd) {
         this(fd, State.CONNECTED, false);
     }
@@ -108,9 +108,12 @@ public class UnixSocketChannel extends AbstractNativeSocketChannel {
     UnixSocketChannel(int fd, State initialState, boolean initialBoundState) {
         super(fd);
         stateLock.writeLock().lock();
-        state = initialState;
-        bindHandler = new BindHandler(initialBoundState);
-        stateLock.writeLock().unlock();
+        try {
+            state = initialState;
+            bindHandler = new BindHandler(initialBoundState);
+        } finally {
+            stateLock.writeLock().unlock();
+        }
     }
 
     private boolean doConnect(SockAddrUnix remote) throws IOException {
@@ -146,7 +149,7 @@ public class UnixSocketChannel extends AbstractNativeSocketChannel {
             return true;
         }
     }
-    
+
     boolean isBound() {
         return bindHandler.isBound();
     }

--- a/src/test/java/jnr/unixsocket/example/UnixServer.java
+++ b/src/test/java/jnr/unixsocket/example/UnixServer.java
@@ -106,7 +106,7 @@ public class UnixServer {
                 ByteBuffer buf = ByteBuffer.allocate(1024);
                 int n = channel.read(buf);
                 UnixSocketAddress remote = channel.getRemoteSocketAddress();
-                System.out.printf("Read in %d bytes from %s\n", n, remote);
+                System.out.printf("Read in %d bytes from %s%n", n, remote);
 
                 if (n > 0) {
                     buf.flip();


### PR DESCRIPTION
Actually the Travis build on master is broken because of an issue with findbugs 3.
Since findbugs is deprecated, its seems to be better to switch to spotbugs, the successor.
The pom.xml has been updated accordingly and some low hanging fruits have been fixed.

However the test show some concurrency issue, which might be considered to be fixed.

The test for Java 7 has been switched off in Travis as (a) the build is broken (see one of the latest Travis logs) and (b) spotbugs requires Java 8+