### PR TITLE
Update JNR dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-ffi</artifactId>
-      <version>2.2.15</version>
+      <version>2.2.16</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -71,13 +71,13 @@
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-enxio</artifactId>
-      <version>0.32.16</version>
+      <version>0.32.17</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-posix</artifactId>
-      <version>3.1.18</version>
+      <version>3.1.19</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
* jnr-ffi 2.2.16
  * Update jffi to 1.3.13 (https://github.com/jnr/jnr-ffi/pull/342).
* jnr-posix 3.1.19
  * LinuxLibC interface is incompatible with musl libc (https://github.com/jnr/jnr-posix/issues/187).
  * handle UnsatisfiedLinkError in LinuxPOSIX constructor (https://github.com/jnr/jnr-posix/pull/188).
  * Update jnr-ffi to 2.1.16 (https://github.com/jnr/jnr-posix/pull/189).
* jnr-enxio 0.32.17
  * Update jnr-ffi to 2.1.16 (https://github.com/jnr/jnr-posix/pull/189).